### PR TITLE
fix: CI build failure + deprecation warnings

### DIFF
--- a/docs/tuple-support.md
+++ b/docs/tuple-support.md
@@ -1,0 +1,164 @@
+# Tuple Support
+
+## Overview
+
+Tuples are lightweight, immutable, fixed-size data structures. They serve as pure data containers -- behavior is provided through standalone functions, not methods.
+
+**Key distinction from classes:** Classes bundle data + behavior. Tuples are just structured data.
+
+**Key distinction from frozen arrays (`#[...]`):** Frozen arrays are untyped, homogeneous-feeling collections. Named tuples carry a type tag, enforce per-field types at construction, support named field access. Anonymous tuples are closer to frozen arrays but still support type enforcement and destructuring.
+
+## Syntax
+
+### Defining a tuple type
+
+```gene
+(tuple Point x: Int y: Int)
+(tuple X first: String Int Int)    # mixed named/positional fields
+(tuple Pair Int Int)               # all positional
+```
+
+Fields can be named (`x: Int`) or positional (`Int`). Named fields are accessed by name or index; positional fields by index only.
+
+### Field ordering
+
+Fields are ordered by declaration order, left to right. Index 0 is always the first declared field, regardless of whether it is named or positional. In `(tuple X first: String Int Int)`:
+
+| Index | Name    | Type   |
+|-------|---------|--------|
+| 0     | `first` | String |
+| 1     | (none)  | Int    |
+| 2     | (none)  | Int    |
+
+### Creating instances
+
+```gene
+# Named tuple type
+(var p (new Point 3 4))
+
+# Anonymous tuple
+(var pair (new tuple "hello" 42))
+```
+
+Constructor arguments are positional, matching declaration order.
+
+### Accessing fields
+
+```gene
+# By name (named fields only)
+p/x    => 3
+p/y    => 4
+
+# By index (all fields)
+p/0    => 3
+p/1    => 4
+
+# Anonymous tuples - index only
+pair/0 => "hello"
+pair/1 => 42
+```
+
+## Properties
+
+### Immutability
+
+Tuples are immutable after construction. To create a modified copy, use the `tuple_with` builtin:
+
+```gene
+(var p1 (new Point 3 4))
+(var p2 (tuple_with p1 ^x 10))
+p2/x => 10
+p2/y => 4
+
+# Positional update by index:
+(var t (new tuple 1 2 3))
+(var t2 (tuple_with t ^0 10))
+t2/0 => 10
+```
+
+`tuple_with` is a standalone function, consistent with the pure-data model. It returns a new tuple; the original is unchanged.
+
+### Type enforcement
+
+Field types are enforced at construction time (and by `tuple_with`). Passing a value that doesn't match the declared type is a runtime error.
+
+```gene
+(tuple Pair String Int)
+(new Pair "hello" 42)     # ok
+(new Pair 42 "hello")     # runtime error: expected String, got Int
+```
+
+### Nominal typing
+
+Tuple types are nominal -- the type name is the identity. Two tuple types with the same fields but different names are distinct types.
+
+```gene
+(tuple Point x: Int y: Int)
+(tuple Vec2 x: Int y: Int)
+
+(== (new Point 3 4) (new Point 3 4))   => true   # same type, same values
+(== (new Point 3 4) (new Vec2 3 4))    => false   # different types
+(== (new Point 3 4) (new Point 3 5))   => false   # same type, different values
+```
+
+Anonymous tuples compare structurally by field count and values (they have no type name).
+
+### Destructuring
+
+```gene
+(var [x y] p)           # positional destructure
+x => 3
+y => 4
+
+(var [first _ third] t)  # skip fields with _
+```
+
+### Pattern matching
+
+Uses `case`/`when` (Gene's pattern matching construct):
+
+```gene
+(case point
+  when (Point 0 0)      "origin"
+  when (Point x 0)      #"on x-axis at #{x}"
+  when (Point 0 y)      #"on y-axis at #{y}"
+  when (Point x y)      #"at #{x}, #{y}"
+)
+```
+
+## Behavior model
+
+Tuples are pure data. Use standalone functions to operate on them:
+
+```gene
+(fn distance [a b]
+  (math/sqrt ((((a/x - b/x) ** 2)) + ((a/y - b/y) ** 2)))
+)
+
+(var p1 (new Point 0 0))
+(var p2 (new Point 3 4))
+(distance p1 p2)  => 5.0
+```
+
+## Examples
+
+```gene
+# RGB color as a tuple
+(tuple Color r: Int g: Int b: Int)
+(var red (new Color 255 0 0))
+
+(fn color_to_hex [c]
+  #"##(hex c/r)#(hex c/g)#(hex c/b)"
+)
+
+# Return multiple values from a function
+(fn divmod [a b]
+  (new tuple (a / b) (a % b))
+)
+(var [quotient remainder] (divmod 10 3))
+
+# Lightweight records
+(tuple HttpResponse status: Int body: String)
+(var resp (new HttpResponse 200 "OK"))
+resp/status => 200
+```

--- a/gene.nimble
+++ b/gene.nimble
@@ -135,6 +135,7 @@ task testintegration, "Runs non-unit integration tests":
   exec "nim c -r tests/integration/test_stdlib_array.nim"
   exec "nim c -r tests/integration/test_stdlib_map.nim"
   exec "nim c -r tests/integration/test_hash_map.nim"
+  exec "nim c -r tests/integration/test_hash_set.nim"
   exec "nim c -r tests/integration/test_stdlib_gene.nim"
   exec "nim c -r tests/integration/test_stdlib_regex.nim"
   exec "nim c -r tests/integration/test_stdlib_json.nim"

--- a/openspec/changes/add-hashset/design.md
+++ b/openspec/changes/add-hashset/design.md
@@ -16,7 +16,6 @@ Gene's current collection surface does not provide a first-class set optimized f
   - Introduce a set literal syntax in this change.
   - Change `{}` / `Map` or `{{}}` / `HashMap` semantics.
   - Define a serialization format for `HashSet` in this change.
-  - Replace the existing generic `Set` naming elsewhere unless directly required for this runtime type.
 
 ## Decisions
 

--- a/openspec/changes/add-hashset/design.md
+++ b/openspec/changes/add-hashset/design.md
@@ -1,0 +1,65 @@
+## Context
+
+Gene's current collection surface does not provide a first-class set optimized for membership checks and deduplication across arbitrary values. Arrays require linear scans, and emulating sets with `HashMap` adds noise and extra value storage that callers do not care about.
+
+`HashSet` fills that gap as a native runtime collection focused on membership, iteration, and standard set algebra. The design should stay aligned with the new `HashMap` semantics where possible so users get one consistent notion of "hashable value" across keyed collections.
+
+## Goals / Non-Goals
+
+- Goals:
+  - Add a Nim-backed `HashSet` runtime type for general-purpose membership and deduplication over arbitrary `Value`s.
+  - Expose `HashSet` through `(new HashSet ...)` without requiring a literal syntax in the first implementation.
+  - Reuse the same hash-plus-`==` identity contract as `HashMap`.
+  - Support built-in scalar values, structural composite values, and user-defined objects that expose `.hash`.
+  - Ship iteration and core set algebra helpers in the first implementation.
+- Non-Goals:
+  - Introduce a set literal syntax in this change.
+  - Change `{}` / `Map` or `{{}}` / `HashMap` semantics.
+  - Define a serialization format for `HashSet` in this change.
+  - Replace the existing generic `Set` naming elsewhere unless directly required for this runtime type.
+
+## Decisions
+
+- Decision: make `HashSet` constructor-only for now via `(new HashSet item1 item2 ...)`.
+  - Alternatives considered: introducing a literal now. Rejected because the explored literal candidates either conflict with existing syntax or need a separate parser design pass.
+
+- Decision: define `HashSet` member identity as computed hash plus runtime `==`.
+  - Alternatives considered: object identity or hash-only membership. Rejected because the collection should align with `HashMap` and must not alias unequal members that share a hash.
+
+- Decision: reuse `HashMap` hashing behavior for `HashSet`.
+  - Alternatives considered: a separate set-only hashing path. Rejected because the semantics should stay consistent across arbitrary-key collections and duplicated hashing logic would drift.
+
+- Decision: make `.has` the canonical membership method and keep `.contains` as an alias.
+  - Alternatives considered: documenting both names as equally primary. Rejected because one canonical name is simpler for docs and tests.
+
+- Decision: have `.add` mutate and return `self`.
+  - Alternatives considered: returning the inserted value or a boolean. Rejected because chained mutating collection APIs are already the more useful shape here.
+
+- Decision: have `.delete` return the removed member when present, or `nil` when absent.
+  - Alternatives considered: returning booleans only. Rejected because returning the removed value is both informative and matches the design note.
+
+- Decision: include `.to_array` plus `for` iteration support in the first implementation.
+  - Alternatives considered: shipping only membership operations first. Rejected because a set without iteration is incomplete for real use.
+
+- Decision: include `.union`, `.intersect`, `.diff`, and `.subset?` in the first implementation.
+  - Alternatives considered: deferring set algebra to a follow-up. Rejected because these operations are core to why users reach for a set in the first place.
+
+- Decision: render `HashSet` values as `(HashSet item1 item2 ...)`.
+  - Alternatives considered: object-style printing or a speculative literal form. Rejected because the constructor form is the public surface in this change.
+
+## Risks / Trade-offs
+
+- Mutable composite members can become unreachable if their hash-relevant contents change after insertion.
+- If `HashMap` hashing semantics change, `HashSet` must stay in lockstep or membership behavior will diverge.
+- Constructor-only surface is deliberately conservative and may feel less lightweight than a literal until a later parser change lands.
+
+## Migration Plan
+
+1. Approve the `HashSet` surface and semantics.
+2. Land the runtime representation, hashing reuse, stdlib registration, and iteration support.
+3. Add integration coverage for membership, algebra, iteration, printing, and unhashable-member errors.
+4. Revisit literal syntax later if real user demand justifies a dedicated parser change.
+
+## Follow-Up
+
+- Evaluate a future literal syntax such as `|a b c|` only if constructor-only `HashSet` proves too verbose in practice.

--- a/openspec/changes/add-hashset/proposal.md
+++ b/openspec/changes/add-hashset/proposal.md
@@ -1,0 +1,16 @@
+## Why
+
+Gene has `Map` for symbol-keyed property data and now `HashMap` for arbitrary key/value lookups, but it still lacks a native arbitrary-value set for membership tests, deduplication, and common set algebra. Users currently have to emulate sets with maps or arrays, which is awkward and slower than a dedicated runtime collection.
+
+## What Changes
+
+- Add `HashSet` as a concrete mutable set type for arbitrary `Value` members, constructed with `(new HashSet item1 item2 item3 ...)`.
+- Add core `HashSet` methods for collection use: `.has` (canonical), `.contains` (alias), `.add`, `.delete`, `.size`, `.clear`, `.to_array`, `.union`, `.intersect`, `.diff`, and `.subset?`.
+- Define `HashSet` member identity as computed hash plus runtime `==`, matching `HashMap` key semantics.
+- Define `$` / `println` rendering for `HashSet` as `(HashSet item1 item2 item3 ...)` so printed values align with the constructor form.
+- Make `HashSet` iterable in `for` loops without introducing a literal syntax in this change.
+
+## Impact
+
+- Affected specs: `hash-set`
+- Affected code: runtime collection/value types, stdlib class registration, hash/equality helpers, iteration support, printing/diagnostics, and integration tests

--- a/openspec/changes/add-hashset/specs/hash-set/spec.md
+++ b/openspec/changes/add-hashset/specs/hash-set/spec.md
@@ -1,0 +1,91 @@
+## ADDED Requirements
+
+### Requirement: HashSet Constructs Through The Class Constructor
+The system SHALL provide `HashSet` as a mutable arbitrary-value set constructed through `(new HashSet item1 item2 item3 ...)`.
+
+#### Scenario: Construct with initial members
+- **WHEN** a program evaluates `(var s (new HashSet 1 "two" [3 4]))`
+- **THEN** `s` is a `HashSet` value
+- **AND** `(s .has 1)` returns `true`
+- **AND** `(s .has "two")` returns `true`
+- **AND** `(s .has [3 4])` returns `true`
+
+#### Scenario: Empty constructor creates an empty HashSet
+- **WHEN** a program evaluates `(new HashSet)`
+- **THEN** the result is an empty `HashSet`
+
+#### Scenario: Duplicate constructor members collapse to one stored member
+- **WHEN** a program evaluates `(var s (new HashSet 1 1 1))`
+- **THEN** `(s .size)` returns `1`
+
+### Requirement: HashSet Uses Hash Plus Equality For Member Identity
+`HashSet` membership MUST resolve members by computed hash and runtime `==`, so hash collisions do not alias unequal values.
+
+#### Scenario: Unequal members with the same hash remain distinct
+- **WHEN** two different values produce the same `HashSet` hash but runtime `==` is false
+- **THEN** adding both members preserves both entries
+- **AND** membership tests succeed only for the equal member being checked
+
+#### Scenario: Structurally equal composite members resolve the same entry
+- **WHEN** a program adds `[1 2]` and later checks membership with another `[1 2]`
+- **THEN** the `HashSet` resolves the existing member
+- **AND** `(s .size)` does not increase for the structurally equal duplicate
+
+### Requirement: HashSet Accepts User-Defined Hashable Objects
+`HashSet` SHALL accept user-defined objects as members when the runtime can compute a hash for them via `.hash`.
+
+#### Scenario: Custom object with hash participates in membership
+- **WHEN** a program adds an object whose class defines `.hash`
+- **THEN** the `HashSet` accepts the member
+- **AND** `.has` with the same key object returns `true`
+
+#### Scenario: Unhashable member is rejected
+- **WHEN** a program attempts to add or check a member for which `HashSet` cannot compute a hash
+- **THEN** execution fails with a clear runtime error indicating the value is not hashable for `HashSet`
+
+### Requirement: HashSet Exposes Core Mutable Set Operations
+`HashSet` SHALL expose explicit collection methods for mutable membership operations.
+
+#### Scenario: Has is canonical and contains is an alias
+- **WHEN** a program checks the same member with `.has` and `.contains`
+- **THEN** both calls return the same membership result
+
+#### Scenario: Add, delete, clear, and size work together
+- **WHEN** a program mutates a `HashSet` via `.add`, removes a member via `.delete`, and clears it via `.clear`
+- **THEN** `.size` reflects each mutation accurately
+- **AND** deleted members are no longer present
+
+#### Scenario: Delete returns removed member or nil
+- **WHEN** a program deletes a present member and then deletes a missing member
+- **THEN** the first call returns the removed member
+- **AND** the second call returns `nil`
+
+### Requirement: HashSet Exposes Iteration Helpers
+`HashSet` SHALL expose iteration helpers so callers can enumerate stored members without reaching into internal storage.
+
+#### Scenario: To_array returns the stored members
+- **WHEN** a program stores multiple members in a `HashSet` and calls `.to_array`
+- **THEN** the result is an array containing the stored members
+
+#### Scenario: For-loop iteration visits each stored member once
+- **WHEN** a program iterates a `HashSet` in a `for` loop
+- **THEN** iteration visits every stored member exactly once
+
+### Requirement: HashSet Exposes Set Algebra
+`HashSet` SHALL expose standard set algebra helpers that return new `HashSet` values or membership booleans as appropriate.
+
+#### Scenario: Union, intersect, and diff produce derived sets
+- **WHEN** a program evaluates `.union`, `.intersect`, and `.diff` across two `HashSet` values
+- **THEN** each operation returns a new `HashSet`
+- **AND** the returned members match the standard set operation semantics
+
+#### Scenario: Subset checks containment across sets
+- **WHEN** a program evaluates `(a .subset? b)`
+- **THEN** the result is `true` only when every member of `a` is present in `b`
+
+### Requirement: HashSet Renders With Constructor Syntax
+`HashSet` SHALL render using `(HashSet ...)` so printed values align with the public constructor form.
+
+#### Scenario: Printed HashSet uses constructor-style output
+- **WHEN** a program prints a `HashSet`
+- **THEN** the output uses `(HashSet item1 item2 item3 ...)` syntax

--- a/openspec/changes/add-hashset/tasks.md
+++ b/openspec/changes/add-hashset/tasks.md
@@ -1,0 +1,8 @@
+## 1. Implementation
+
+- [x] 1.1 Add `HashSet` as a concrete arbitrary-value membership collection and register it in the runtime/stdlib alongside existing collection classes.
+- [x] 1.2 Implement `HashSet` hashing and lookup semantics by reusing `HashMap`-compatible hashing behavior and runtime `==` collision resolution.
+- [x] 1.3 Add constructor support for `(new HashSet item1 item2 ...)` and ensure duplicate inserts collapse to one member.
+- [x] 1.4 Add core `HashSet` methods: `has` with `.contains` as an alias, `add`, `delete`, `size`, `clear`, `to_array`, `union`, `intersect`, `diff`, and `subset?`.
+- [x] 1.5 Make `HashSet` iterable in `for` loops and add `$` / `println` rendering via `(HashSet item1 item2 ...)`.
+- [x] 1.6 Add integration coverage for scalar members, composite members, collision handling, duplicate inserts, iteration, set algebra, printing, and unhashable-member errors.

--- a/src/gene/error_display.nim
+++ b/src/gene/error_display.nim
@@ -1,12 +1,75 @@
+import std/algorithm
+import std/json as nim_json
+import std/strutils
+
 import ./vm/diagnostics
-import ./stdlib/json
-import ./serdes
+
+const
+  DIAGNOSTIC_FIELD_ORDER = ["message", "code", "severity", "stage", "span", "hints", "repair_tags"]
+  DIAGNOSTIC_SPAN_ORDER = ["file", "line", "column"]
+
+proc render_json_node(node: nim_json.JsonNode): string
+
+proc render_json_object(node: nim_json.JsonNode; preferred_order: openArray[string] = []): string =
+  var keys: seq[string] = @[]
+  for key in preferred_order:
+    if node.hasKey(key):
+      keys.add(key)
+
+  var extras: seq[string] = @[]
+  for key, _ in node:
+    var is_preferred = false
+    for preferred in preferred_order:
+      if key == preferred:
+        is_preferred = true
+        break
+    if not is_preferred:
+      extras.add(key)
+  extras.sort(system.cmp[string])
+  keys.add(extras)
+
+  result = "{"
+  for i, key in keys:
+    if i > 0:
+      result &= " "
+    result &= "^" & key & " "
+    if key == "span" and node[key].kind == nim_json.JObject:
+      result &= render_json_object(node[key], DIAGNOSTIC_SPAN_ORDER)
+    else:
+      result &= render_json_node(node[key])
+  result &= "}"
+
+proc render_json_node(node: nim_json.JsonNode): string =
+  case node.kind
+  of nim_json.JNull:
+    "nil"
+  of nim_json.JBool:
+    if node.bval: "true" else: "false"
+  of nim_json.JInt:
+    $int64(node.num)
+  of nim_json.JFloat:
+    $node.fnum
+  of nim_json.JString:
+    nim_json.escapeJson(node.str)
+  of nim_json.JArray:
+    var items: seq[string] = @[]
+    for item in node.elems:
+      items.add(render_json_node(item))
+    "[" & items.join(" ") & "]"
+  of nim_json.JObject:
+    render_json_object(node)
+
+proc render_diagnostic_message(message: string): string =
+  let parsed = nim_json.parseJson(message)
+  if parsed.kind != nim_json.JObject or not parsed.hasKey("code") or not parsed.hasKey("message"):
+    return message
+  render_json_object(parsed, DIAGNOSTIC_FIELD_ORDER)
 
 proc render_error_message*(message: string): string =
   if not is_diagnostic_envelope(message):
     return message
 
   try:
-    return value_to_gene_str(parse_json_string(message))
+    return render_diagnostic_message(message)
   except CatchableError:
     return message

--- a/src/gene/hash_map_support.nim
+++ b/src/gene/hash_map_support.nim
@@ -2,10 +2,12 @@ import hashes, tables
 
 import ./types
 
+proc hash_map_value_hash*(vm: ptr VirtualMachine, key: Value, collection_name = "HashMap"): Hash
+
 proc hash_map_pair_count*(hash_map: Value): int {.inline.} =
   hash_map_items(hash_map).len div 2
 
-proc rebuild_hash_map_index*(hash_map: Value) =
+proc rebuild_hash_map_index*(vm: ptr VirtualMachine, hash_map: Value) =
   if hash_map.kind != VkHashMap:
     not_allowed("Expected HashMap value")
 
@@ -14,7 +16,7 @@ proc rebuild_hash_map_index*(hash_map: Value) =
   var i = 0
   while i + 1 < hash_map_items(hash_map).len:
     let key = hash_map_items(hash_map)[i]
-    let bucket_hash = hash(key)
+    let bucket_hash = hash_map_value_hash(vm, key, "HashMap")
     if hash_map_buckets(hash_map).hasKey(bucket_hash):
       hash_map_buckets(hash_map)[bucket_hash].add(pair_index)
     else:
@@ -35,35 +37,33 @@ proc invoke_hash_method(vm: ptr VirtualMachine, key: Value, meth: Method): Value
   else:
     not_allowed("HashMap key hash method must be callable, got " & $meth.callable.kind)
 
-proc hash_map_value_hash*(vm: ptr VirtualMachine, key: Value): Hash
-
-proc structural_array_hash(vm: ptr VirtualMachine, key: Value): Hash =
+proc structural_array_hash(vm: ptr VirtualMachine, key: Value, collection_name: string): Hash =
   var result_hash: Hash = hash("Array")
   for item in array_data(key):
-    result_hash = result_hash !& hash_map_value_hash(vm, item)
+    result_hash = result_hash !& hash_map_value_hash(vm, item, collection_name)
   !$result_hash
 
-proc structural_map_hash(vm: ptr VirtualMachine, key: Value): Hash =
+proc structural_map_hash(vm: ptr VirtualMachine, key: Value, collection_name: string): Hash =
   var result_hash: Hash = hash("Map") !& hash(map_data(key).len)
   for map_key, map_value in map_data(key):
     var entry_hash: Hash = hash(map_key)
-    entry_hash = entry_hash !& hash_map_value_hash(vm, map_value)
+    entry_hash = entry_hash !& hash_map_value_hash(vm, map_value, collection_name)
     result_hash = result_hash xor !$entry_hash
   !$result_hash
 
-proc structural_hash_map_hash(vm: ptr VirtualMachine, key: Value): Hash =
+proc structural_hash_map_hash(vm: ptr VirtualMachine, key: Value, collection_name: string): Hash =
   var result_hash: Hash = hash("HashMap") !& hash(hash_map_pair_count(key))
   var pair_index = 0
   while pair_index < hash_map_pair_count(key):
     let item_index = pair_index * 2
-    var entry_hash = hash_map_value_hash(vm, hash_map_items(key)[item_index])
+    var entry_hash = hash_map_value_hash(vm, hash_map_items(key)[item_index], collection_name)
     if item_index + 1 < hash_map_items(key).len:
-      entry_hash = entry_hash !& hash_map_value_hash(vm, hash_map_items(key)[item_index + 1])
+      entry_hash = entry_hash !& hash_map_value_hash(vm, hash_map_items(key)[item_index + 1], collection_name)
     result_hash = result_hash xor !$entry_hash
     inc(pair_index)
   !$result_hash
 
-proc hash_map_value_hash*(vm: ptr VirtualMachine, key: Value): Hash =
+proc hash_map_value_hash*(vm: ptr VirtualMachine, key: Value, collection_name = "HashMap"): Hash =
   case key.kind
   of VkNil:
     hash("Nil")
@@ -86,30 +86,30 @@ proc hash_map_value_hash*(vm: ptr VirtualMachine, key: Value): Hash =
   of VkComplexSymbol:
     hash(key.ref.csymbol)
   of VkArray:
-    structural_array_hash(vm, key)
+    structural_array_hash(vm, key, collection_name)
   of VkMap:
-    structural_map_hash(vm, key)
+    structural_map_hash(vm, key, collection_name)
   of VkHashMap:
-    structural_hash_map_hash(vm, key)
+    structural_hash_map_hash(vm, key, collection_name)
   else:
     let key_class = key.get_class()
     if key_class.is_nil:
-      not_allowed("Key is not hashable for HashMap: " & $key.kind)
+      not_allowed("Key is not hashable for " & collection_name & ": " & $key.kind)
 
     let hash_method = key_class.get_method("hash")
     if hash_method.is_nil:
-      not_allowed("Key is not hashable for HashMap: " & $key.kind)
+      not_allowed("Key is not hashable for " & collection_name & ": " & $key.kind)
 
     let hash_value = invoke_hash_method(vm, key, hash_method)
     if hash_value.kind != VkInt:
-      not_allowed("HashMap key .hash must return Int, got " & $hash_value.kind)
+      not_allowed(collection_name & " key .hash must return Int, got " & $hash_value.kind)
     hash(hash_value.to_int())
 
 proc hash_map_find_pair*(vm: ptr VirtualMachine, hash_map: Value, key: Value): int =
   if hash_map.kind != VkHashMap:
     not_allowed("Expected HashMap value")
 
-  let bucket_hash = hash_map_value_hash(vm, key)
+  let bucket_hash = hash_map_value_hash(vm, key, "HashMap")
   let bucket = hash_map_buckets(hash_map).getOrDefault(bucket_hash, @[])
   for pair_index in bucket:
     let item_index = pair_index * 2
@@ -126,7 +126,7 @@ proc hash_map_put*(vm: ptr VirtualMachine, hash_map: Value, key: Value, value: V
     hash_map_items(hash_map)[pair_index * 2 + 1] = value
     return
 
-  let bucket_hash = hash_map_value_hash(vm, key)
+  let bucket_hash = hash_map_value_hash(vm, key, "HashMap")
   let new_pair_index = hash_map_pair_count(hash_map)
   hash_map_items(hash_map).add(key)
   hash_map_items(hash_map).add(value)
@@ -151,5 +151,5 @@ proc hash_map_delete*(vm: ptr VirtualMachine, hash_map: Value, key: Value): tupl
   let removed = hash_map_items(hash_map)[item_index + 1]
   hash_map_items(hash_map).delete(item_index + 1)
   hash_map_items(hash_map).delete(item_index)
-  rebuild_hash_map_index(hash_map)
+  rebuild_hash_map_index(vm, hash_map)
   (true, removed)

--- a/src/gene/hash_set_support.nim
+++ b/src/gene/hash_set_support.nim
@@ -1,0 +1,59 @@
+import tables
+
+import ./types
+import ./hash_map_support
+
+proc hash_set_count*(hash_set: Value): int {.inline.} =
+  hash_set_items(hash_set).len
+
+proc rebuild_hash_set_index*(vm: ptr VirtualMachine, hash_set: Value) =
+  if hash_set.kind != VkSet:
+    not_allowed("Expected HashSet value")
+
+  hash_set_buckets(hash_set).clear()
+  for item_index, item in hash_set_items(hash_set):
+    let bucket_hash = hash_map_value_hash(vm, item, "HashSet")
+    if hash_set_buckets(hash_set).hasKey(bucket_hash):
+      hash_set_buckets(hash_set)[bucket_hash].add(item_index)
+    else:
+      hash_set_buckets(hash_set)[bucket_hash] = @[item_index]
+
+proc hash_set_find*(vm: ptr VirtualMachine, hash_set: Value, item: Value): int =
+  if hash_set.kind != VkSet:
+    not_allowed("Expected HashSet value")
+
+  let bucket_hash = hash_map_value_hash(vm, item, "HashSet")
+  let bucket = hash_set_buckets(hash_set).getOrDefault(bucket_hash, @[])
+  for item_index in bucket:
+    if item_index < hash_set_items(hash_set).len and hash_set_items(hash_set)[item_index] == item:
+      return item_index
+  return -1
+
+proc hash_set_contains*(vm: ptr VirtualMachine, hash_set: Value, item: Value): bool {.inline.} =
+  hash_set_find(vm, hash_set, item) >= 0
+
+proc hash_set_add*(vm: ptr VirtualMachine, hash_set: Value, item: Value): bool =
+  if hash_set.kind != VkSet:
+    not_allowed("Expected HashSet value")
+
+  if hash_set_find(vm, hash_set, item) >= 0:
+    return false
+
+  let bucket_hash = hash_map_value_hash(vm, item, "HashSet")
+  let new_index = hash_set_items(hash_set).len
+  hash_set_items(hash_set).add(item)
+  if hash_set_buckets(hash_set).hasKey(bucket_hash):
+    hash_set_buckets(hash_set)[bucket_hash].add(new_index)
+  else:
+    hash_set_buckets(hash_set)[bucket_hash] = @[new_index]
+  true
+
+proc hash_set_delete*(vm: ptr VirtualMachine, hash_set: Value, item: Value): tuple[found: bool, value: Value] =
+  let item_index = hash_set_find(vm, hash_set, item)
+  if item_index < 0:
+    return (false, NIL)
+
+  let removed = hash_set_items(hash_set)[item_index]
+  hash_set_items(hash_set).delete(item_index)
+  rebuild_hash_set_index(vm, hash_set)
+  (true, removed)

--- a/src/gene/native/runtime.nim
+++ b/src/gene/native/runtime.nim
@@ -26,7 +26,18 @@ type
 
 when defined(posix):
   import std/posix
-  proc clear_cache(start, `end`: ptr char) {.importc: "__builtin___clear_cache".}
+  when defined(macosx):
+    proc sys_icache_invalidate(start: pointer, size: csize_t) {.importc, header: "<libkern/OSCacheControl.h>".}
+  proc clear_cache(start, `end`: ptr char) {.inline.} =
+    when defined(macosx):
+      sys_icache_invalidate(start, cast[uint](`end`) - cast[uint](start))
+    elif defined(amd64):
+      # x86_64 maintains cache coherency in hardware — no flush needed
+      discard
+    else:
+      # ARM/other: use __builtin___clear_cache (available on GCC/Clang for ARM)
+      proc builtin_clear_cache(start, `end`: pointer) {.importc: "__builtin___clear_cache", nodecl.}
+      builtin_clear_cache(start, `end`)
   when defined(macosx):
     proc pthread_jit_write_protect_np(enable: cint) {.importc.}
 

--- a/src/gene/serdes.nim
+++ b/src/gene/serdes.nim
@@ -1675,7 +1675,7 @@ proc lazy_tree_class_ref(value: Value): Class {.gcsafe.} =
   of VkDateTime:
     class_value_ref(App.app.datetime_class)
   of VkSet:
-    class_value_ref(if App.app.set_class.kind == VkClass: App.app.set_class else: App.app.object_class)
+    class_value_ref(if App.app.hash_set_class.kind == VkClass: App.app.hash_set_class else: App.app.object_class)
   of VkFuture:
     class_value_ref(if App.app.future_class.kind == VkClass: App.app.future_class else: App.app.object_class)
   of VkGenerator:

--- a/src/gene/stdlib/classes.nim
+++ b/src/gene/stdlib/classes.nim
@@ -46,6 +46,11 @@ proc display_value*(val: Value; top_level: bool): string {.gcsafe.} =
         parts.add(display_value(val.ref.hash_map_items[i + 1], false))
       i += 2
     "{{" & parts.join(" ") & "}}"
+  of VkSet:
+    var parts: seq[string] = @[]
+    for item in val.ref.set_items:
+      parts.add(display_value(item, false))
+    "(HashSet" & (if parts.len > 0: " " & parts.join(" ") else: "") & ")"
   of VkGene:
     var segments: seq[string] = @[]
     if not val.gene.type.is_nil():

--- a/src/gene/stdlib/classes.nim
+++ b/src/gene/stdlib/classes.nim
@@ -99,8 +99,8 @@ proc value_class_value*(val: Value): Value =
   of VkDateTime:
     App.app.datetime_class
   of VkSet:
-    if App.app.set_class.kind == VkClass:
-      App.app.set_class
+    if App.app.hash_set_class.kind == VkClass:
+      App.app.hash_set_class
     else:
       App.app.object_class
   of VkFuture:

--- a/src/gene/stdlib/collections.nim
+++ b/src/gene/stdlib/collections.nim
@@ -2,6 +2,7 @@ import strutils, tables, algorithm
 
 import ../types
 import ../hash_map_support
+import ../hash_set_support
 import ./classes
 import ./json
 
@@ -1402,11 +1403,207 @@ proc init_collection_classes*(object_class: Class) =
 
 proc init_set_class*(object_class: Class) =
   var r: ptr Reference
-  let set_class = new_class("Set")
+  let set_class = new_class("HashSet")
   set_class.parent = object_class
   set_class.def_native_method("to_s", object_to_s_method)
   r = new_ref(VkClass)
   r.class = set_class
   App.app.set_class = r.to_ref_value()
+  App.app.gene_ns.ns["HashSet".to_key()] = App.app.set_class
+  App.app.global_ns.ns["HashSet".to_key()] = App.app.set_class
   App.app.gene_ns.ns["Set".to_key()] = App.app.set_class
   App.app.global_ns.ns["Set".to_key()] = App.app.set_class
+
+  proc hash_set_constructor(vm: ptr VirtualMachine, args: ptr UncheckedArray[Value], arg_count: int, has_keyword_args: bool): Value {.gcsafe.} =
+    if has_keyword_args:
+      not_allowed("HashSet constructor does not accept keyword arguments")
+    let result_set = new_set_value()
+    for i in 0..<arg_count:
+      {.cast(gcsafe).}:
+        discard hash_set_add(vm, result_set, args[i])
+    result_set
+
+  set_class.def_native_constructor(hash_set_constructor)
+
+  proc vm_hash_set_has(vm: ptr VirtualMachine, args: ptr UncheckedArray[Value], arg_count: int, has_keyword_args: bool): Value {.gcsafe.} =
+    if get_positional_count(arg_count, has_keyword_args) < 2:
+      not_allowed("HashSet.has expects a member argument")
+
+    let hash_set = get_positional_arg(args, 0, has_keyword_args)
+    if hash_set.kind != VkSet:
+      not_allowed("HashSet.has must be called on a HashSet")
+
+    let found = block:
+      {.cast(gcsafe).}:
+        hash_set_contains(vm, hash_set, get_positional_arg(args, 1, has_keyword_args))
+    found.to_value()
+
+  set_class.def_native_method("has", vm_hash_set_has, @[("member", NIL)], App.app.bool_class)
+  set_class.def_native_method("contains", vm_hash_set_has, @[("member", NIL)], App.app.bool_class)
+
+  proc vm_hash_set_add(vm: ptr VirtualMachine, args: ptr UncheckedArray[Value], arg_count: int, has_keyword_args: bool): Value {.gcsafe.} =
+    if get_positional_count(arg_count, has_keyword_args) < 2:
+      not_allowed("HashSet.add expects at least one member argument")
+
+    let hash_set = get_positional_arg(args, 0, has_keyword_args)
+    if hash_set.kind != VkSet:
+      not_allowed("HashSet.add must be called on a HashSet")
+
+    for i in 1..<get_positional_count(arg_count, has_keyword_args):
+      {.cast(gcsafe).}:
+        discard hash_set_add(vm, hash_set, get_positional_arg(args, i, has_keyword_args))
+    hash_set
+
+  set_class.def_native_method("add", vm_hash_set_add)
+
+  proc vm_hash_set_delete(vm: ptr VirtualMachine, args: ptr UncheckedArray[Value], arg_count: int, has_keyword_args: bool): Value {.gcsafe.} =
+    if get_positional_count(arg_count, has_keyword_args) < 2:
+      not_allowed("HashSet.delete expects at least one member argument")
+
+    let hash_set = get_positional_arg(args, 0, has_keyword_args)
+    if hash_set.kind != VkSet:
+      not_allowed("HashSet.delete must be called on a HashSet")
+
+    var last_removed = NIL
+    for i in 1..<get_positional_count(arg_count, has_keyword_args):
+      let deleted = block:
+        {.cast(gcsafe).}:
+          hash_set_delete(vm, hash_set, get_positional_arg(args, i, has_keyword_args))
+      if deleted.found:
+        last_removed = deleted.value
+    last_removed
+
+  set_class.def_native_method("delete", vm_hash_set_delete)
+  set_class.def_native_method("del", vm_hash_set_delete)
+
+  proc vm_hash_set_size(vm: ptr VirtualMachine, args: ptr UncheckedArray[Value], arg_count: int, has_keyword_args: bool): Value {.gcsafe.} =
+    if get_positional_count(arg_count, has_keyword_args) < 1:
+      not_allowed("HashSet.size requires self")
+    let hash_set = get_positional_arg(args, 0, has_keyword_args)
+    if hash_set.kind != VkSet:
+      not_allowed("HashSet.size must be called on a HashSet")
+    hash_set_count(hash_set).to_value()
+
+  set_class.def_native_method("size", vm_hash_set_size, @[], App.app.int_class)
+
+  proc vm_hash_set_clear(vm: ptr VirtualMachine, args: ptr UncheckedArray[Value], arg_count: int, has_keyword_args: bool): Value {.gcsafe.} =
+    if get_positional_count(arg_count, has_keyword_args) < 1:
+      not_allowed("HashSet.clear requires self")
+    let hash_set = get_positional_arg(args, 0, has_keyword_args)
+    if hash_set.kind != VkSet:
+      not_allowed("HashSet.clear must be called on a HashSet")
+    hash_set_items(hash_set).setLen(0)
+    hash_set_buckets(hash_set).clear()
+    hash_set
+
+  set_class.def_native_method("clear", vm_hash_set_clear)
+
+  proc vm_hash_set_to_array(vm: ptr VirtualMachine, args: ptr UncheckedArray[Value], arg_count: int, has_keyword_args: bool): Value {.gcsafe.} =
+    if get_positional_count(arg_count, has_keyword_args) < 1:
+      not_allowed("HashSet.to_array requires self")
+    let hash_set = get_positional_arg(args, 0, has_keyword_args)
+    if hash_set.kind != VkSet:
+      not_allowed("HashSet.to_array must be called on a HashSet")
+    let result_array = new_array_value()
+    for item in hash_set_items(hash_set):
+      array_data(result_array).add(item)
+    result_array
+
+  set_class.def_native_method("to_array", vm_hash_set_to_array, @[], App.app.array_class)
+
+  proc vm_hash_set_iter(vm: ptr VirtualMachine, args: ptr UncheckedArray[Value], arg_count: int, has_keyword_args: bool): Value {.gcsafe, nimcall.} =
+    if get_positional_count(arg_count, has_keyword_args) < 1:
+      not_allowed("HashSet.iter requires self")
+    let hash_set = get_positional_arg(args, 0, has_keyword_args)
+    if hash_set.kind != VkSet:
+      not_allowed("HashSet.iter must be called on a HashSet")
+    let iterator_class_val = App.app.gene_ns.ns["ArrayIterator".to_key()]
+    if iterator_class_val.kind != VkClass or iterator_class_val.ref.class == nil:
+      not_allowed("ArrayIterator class is not initialized")
+    let iter_val = new_instance_value(iterator_class_val.ref.class)
+    instance_props(iter_val)["array".to_key()] = vm_hash_set_to_array(vm, args, arg_count, has_keyword_args)
+    instance_props(iter_val)["index".to_key()] = 0.to_value()
+    iter_val
+
+  set_class.def_native_method("iter", vm_hash_set_iter)
+
+  proc require_hash_set_arg(args: ptr UncheckedArray[Value], arg_count: int, has_keyword_args: bool, index: int, method_name: string): Value {.inline, gcsafe.} =
+    if get_positional_count(arg_count, has_keyword_args) <= index:
+      not_allowed("HashSet." & method_name & " expects another HashSet")
+    let other = get_positional_arg(args, index, has_keyword_args)
+    if other.kind != VkSet:
+      not_allowed("HashSet." & method_name & " expects a HashSet argument")
+    other
+
+  proc vm_hash_set_union(vm: ptr VirtualMachine, args: ptr UncheckedArray[Value], arg_count: int, has_keyword_args: bool): Value {.gcsafe.} =
+    if get_positional_count(arg_count, has_keyword_args) < 2:
+      not_allowed("HashSet.union expects another HashSet")
+    let hash_set = get_positional_arg(args, 0, has_keyword_args)
+    if hash_set.kind != VkSet:
+      not_allowed("HashSet.union must be called on a HashSet")
+    let other = require_hash_set_arg(args, arg_count, has_keyword_args, 1, "union")
+    let result_set = new_set_value()
+    for item in hash_set_items(hash_set):
+      {.cast(gcsafe).}:
+        discard hash_set_add(vm, result_set, item)
+    for item in hash_set_items(other):
+      {.cast(gcsafe).}:
+        discard hash_set_add(vm, result_set, item)
+    result_set
+
+  set_class.def_native_method("union", vm_hash_set_union)
+
+  proc vm_hash_set_intersect(vm: ptr VirtualMachine, args: ptr UncheckedArray[Value], arg_count: int, has_keyword_args: bool): Value {.gcsafe.} =
+    if get_positional_count(arg_count, has_keyword_args) < 2:
+      not_allowed("HashSet.intersect expects another HashSet")
+    let hash_set = get_positional_arg(args, 0, has_keyword_args)
+    if hash_set.kind != VkSet:
+      not_allowed("HashSet.intersect must be called on a HashSet")
+    let other = require_hash_set_arg(args, arg_count, has_keyword_args, 1, "intersect")
+    let result_set = new_set_value()
+    for item in hash_set_items(hash_set):
+      let present = block:
+        {.cast(gcsafe).}:
+          hash_set_contains(vm, other, item)
+      if present:
+        {.cast(gcsafe).}:
+          discard hash_set_add(vm, result_set, item)
+    result_set
+
+  set_class.def_native_method("intersect", vm_hash_set_intersect)
+
+  proc vm_hash_set_diff(vm: ptr VirtualMachine, args: ptr UncheckedArray[Value], arg_count: int, has_keyword_args: bool): Value {.gcsafe.} =
+    if get_positional_count(arg_count, has_keyword_args) < 2:
+      not_allowed("HashSet.diff expects another HashSet")
+    let hash_set = get_positional_arg(args, 0, has_keyword_args)
+    if hash_set.kind != VkSet:
+      not_allowed("HashSet.diff must be called on a HashSet")
+    let other = require_hash_set_arg(args, arg_count, has_keyword_args, 1, "diff")
+    let result_set = new_set_value()
+    for item in hash_set_items(hash_set):
+      let present = block:
+        {.cast(gcsafe).}:
+          hash_set_contains(vm, other, item)
+      if not present:
+        {.cast(gcsafe).}:
+          discard hash_set_add(vm, result_set, item)
+    result_set
+
+  set_class.def_native_method("diff", vm_hash_set_diff)
+
+  proc vm_hash_set_subset(vm: ptr VirtualMachine, args: ptr UncheckedArray[Value], arg_count: int, has_keyword_args: bool): Value {.gcsafe.} =
+    if get_positional_count(arg_count, has_keyword_args) < 2:
+      not_allowed("HashSet.subset? expects another HashSet")
+    let hash_set = get_positional_arg(args, 0, has_keyword_args)
+    if hash_set.kind != VkSet:
+      not_allowed("HashSet.subset? must be called on a HashSet")
+    let other = require_hash_set_arg(args, arg_count, has_keyword_args, 1, "subset?")
+    for item in hash_set_items(hash_set):
+      let present = block:
+        {.cast(gcsafe).}:
+          hash_set_contains(vm, other, item)
+      if not present:
+        return FALSE
+    TRUE
+
+  set_class.def_native_method("subset?", vm_hash_set_subset, @[("other", NIL)], App.app.bool_class)

--- a/src/gene/stdlib/collections.nim
+++ b/src/gene/stdlib/collections.nim
@@ -1401,18 +1401,16 @@ proc init_collection_classes*(object_class: Class) =
 
   hash_map_class.def_native_method("immutable?", vm_hash_map_immutable, @[], App.app.bool_class)
 
-proc init_set_class*(object_class: Class) =
+proc init_hash_set_class*(object_class: Class) =
   var r: ptr Reference
-  let set_class = new_class("HashSet")
-  set_class.parent = object_class
-  set_class.def_native_method("to_s", object_to_s_method)
+  let hash_set_class = new_class("HashSet")
+  hash_set_class.parent = object_class
+  hash_set_class.def_native_method("to_s", object_to_s_method)
   r = new_ref(VkClass)
-  r.class = set_class
-  App.app.set_class = r.to_ref_value()
-  App.app.gene_ns.ns["HashSet".to_key()] = App.app.set_class
-  App.app.global_ns.ns["HashSet".to_key()] = App.app.set_class
-  App.app.gene_ns.ns["Set".to_key()] = App.app.set_class
-  App.app.global_ns.ns["Set".to_key()] = App.app.set_class
+  r.class = hash_set_class
+  App.app.hash_set_class = r.to_ref_value()
+  App.app.gene_ns.ns["HashSet".to_key()] = App.app.hash_set_class
+  App.app.global_ns.ns["HashSet".to_key()] = App.app.hash_set_class
 
   proc hash_set_constructor(vm: ptr VirtualMachine, args: ptr UncheckedArray[Value], arg_count: int, has_keyword_args: bool): Value {.gcsafe.} =
     if has_keyword_args:
@@ -1423,7 +1421,7 @@ proc init_set_class*(object_class: Class) =
         discard hash_set_add(vm, result_set, args[i])
     result_set
 
-  set_class.def_native_constructor(hash_set_constructor)
+  hash_set_class.def_native_constructor(hash_set_constructor)
 
   proc vm_hash_set_has(vm: ptr VirtualMachine, args: ptr UncheckedArray[Value], arg_count: int, has_keyword_args: bool): Value {.gcsafe.} =
     if get_positional_count(arg_count, has_keyword_args) < 2:
@@ -1438,8 +1436,8 @@ proc init_set_class*(object_class: Class) =
         hash_set_contains(vm, hash_set, get_positional_arg(args, 1, has_keyword_args))
     found.to_value()
 
-  set_class.def_native_method("has", vm_hash_set_has, @[("member", NIL)], App.app.bool_class)
-  set_class.def_native_method("contains", vm_hash_set_has, @[("member", NIL)], App.app.bool_class)
+  hash_set_class.def_native_method("has", vm_hash_set_has, @[("member", NIL)], App.app.bool_class)
+  hash_set_class.def_native_method("contains", vm_hash_set_has, @[("member", NIL)], App.app.bool_class)
 
   proc vm_hash_set_add(vm: ptr VirtualMachine, args: ptr UncheckedArray[Value], arg_count: int, has_keyword_args: bool): Value {.gcsafe.} =
     if get_positional_count(arg_count, has_keyword_args) < 2:
@@ -1454,7 +1452,7 @@ proc init_set_class*(object_class: Class) =
         discard hash_set_add(vm, hash_set, get_positional_arg(args, i, has_keyword_args))
     hash_set
 
-  set_class.def_native_method("add", vm_hash_set_add)
+  hash_set_class.def_native_method("add", vm_hash_set_add)
 
   proc vm_hash_set_delete(vm: ptr VirtualMachine, args: ptr UncheckedArray[Value], arg_count: int, has_keyword_args: bool): Value {.gcsafe.} =
     if get_positional_count(arg_count, has_keyword_args) < 2:
@@ -1473,8 +1471,8 @@ proc init_set_class*(object_class: Class) =
         last_removed = deleted.value
     last_removed
 
-  set_class.def_native_method("delete", vm_hash_set_delete)
-  set_class.def_native_method("del", vm_hash_set_delete)
+  hash_set_class.def_native_method("delete", vm_hash_set_delete)
+  hash_set_class.def_native_method("del", vm_hash_set_delete)
 
   proc vm_hash_set_size(vm: ptr VirtualMachine, args: ptr UncheckedArray[Value], arg_count: int, has_keyword_args: bool): Value {.gcsafe.} =
     if get_positional_count(arg_count, has_keyword_args) < 1:
@@ -1484,7 +1482,7 @@ proc init_set_class*(object_class: Class) =
       not_allowed("HashSet.size must be called on a HashSet")
     hash_set_count(hash_set).to_value()
 
-  set_class.def_native_method("size", vm_hash_set_size, @[], App.app.int_class)
+  hash_set_class.def_native_method("size", vm_hash_set_size, @[], App.app.int_class)
 
   proc vm_hash_set_clear(vm: ptr VirtualMachine, args: ptr UncheckedArray[Value], arg_count: int, has_keyword_args: bool): Value {.gcsafe.} =
     if get_positional_count(arg_count, has_keyword_args) < 1:
@@ -1496,7 +1494,7 @@ proc init_set_class*(object_class: Class) =
     hash_set_buckets(hash_set).clear()
     hash_set
 
-  set_class.def_native_method("clear", vm_hash_set_clear)
+  hash_set_class.def_native_method("clear", vm_hash_set_clear)
 
   proc vm_hash_set_to_array(vm: ptr VirtualMachine, args: ptr UncheckedArray[Value], arg_count: int, has_keyword_args: bool): Value {.gcsafe.} =
     if get_positional_count(arg_count, has_keyword_args) < 1:
@@ -1509,7 +1507,7 @@ proc init_set_class*(object_class: Class) =
       array_data(result_array).add(item)
     result_array
 
-  set_class.def_native_method("to_array", vm_hash_set_to_array, @[], App.app.array_class)
+  hash_set_class.def_native_method("to_array", vm_hash_set_to_array, @[], App.app.array_class)
 
   proc vm_hash_set_iter(vm: ptr VirtualMachine, args: ptr UncheckedArray[Value], arg_count: int, has_keyword_args: bool): Value {.gcsafe, nimcall.} =
     if get_positional_count(arg_count, has_keyword_args) < 1:
@@ -1525,7 +1523,7 @@ proc init_set_class*(object_class: Class) =
     instance_props(iter_val)["index".to_key()] = 0.to_value()
     iter_val
 
-  set_class.def_native_method("iter", vm_hash_set_iter)
+  hash_set_class.def_native_method("iter", vm_hash_set_iter)
 
   proc require_hash_set_arg(args: ptr UncheckedArray[Value], arg_count: int, has_keyword_args: bool, index: int, method_name: string): Value {.inline, gcsafe.} =
     if get_positional_count(arg_count, has_keyword_args) <= index:
@@ -1551,7 +1549,7 @@ proc init_set_class*(object_class: Class) =
         discard hash_set_add(vm, result_set, item)
     result_set
 
-  set_class.def_native_method("union", vm_hash_set_union)
+  hash_set_class.def_native_method("union", vm_hash_set_union)
 
   proc vm_hash_set_intersect(vm: ptr VirtualMachine, args: ptr UncheckedArray[Value], arg_count: int, has_keyword_args: bool): Value {.gcsafe.} =
     if get_positional_count(arg_count, has_keyword_args) < 2:
@@ -1570,7 +1568,7 @@ proc init_set_class*(object_class: Class) =
           discard hash_set_add(vm, result_set, item)
     result_set
 
-  set_class.def_native_method("intersect", vm_hash_set_intersect)
+  hash_set_class.def_native_method("intersect", vm_hash_set_intersect)
 
   proc vm_hash_set_diff(vm: ptr VirtualMachine, args: ptr UncheckedArray[Value], arg_count: int, has_keyword_args: bool): Value {.gcsafe.} =
     if get_positional_count(arg_count, has_keyword_args) < 2:
@@ -1589,7 +1587,7 @@ proc init_set_class*(object_class: Class) =
           discard hash_set_add(vm, result_set, item)
     result_set
 
-  set_class.def_native_method("diff", vm_hash_set_diff)
+  hash_set_class.def_native_method("diff", vm_hash_set_diff)
 
   proc vm_hash_set_subset(vm: ptr VirtualMachine, args: ptr UncheckedArray[Value], arg_count: int, has_keyword_args: bool): Value {.gcsafe.} =
     if get_positional_count(arg_count, has_keyword_args) < 2:
@@ -1606,4 +1604,4 @@ proc init_set_class*(object_class: Class) =
         return FALSE
     TRUE
 
-  set_class.def_native_method("subset?", vm_hash_set_subset, @[("other", NIL)], App.app.bool_class)
+  hash_set_class.def_native_method("subset?", vm_hash_set_subset, @[("other", NIL)], App.app.bool_class)

--- a/src/gene/stdlib/core.nim
+++ b/src/gene/stdlib/core.nim
@@ -82,6 +82,11 @@ proc display_value(val: Value; topLevel: bool): string {.gcsafe.} =
         parts.add(display_value(val.ref.hash_map_items[i + 1], false))
       i += 2
     "{{" & parts.join(" ") & "}}"
+  of VkSet:
+    var parts: seq[string] = @[]
+    for item in val.ref.set_items:
+      parts.add(display_value(item, false))
+    "(HashSet" & (if parts.len > 0: " " & parts.join(" ") else: "") & ")"
   of VkGene:
     var segments: seq[string] = @[]
     if not val.gene.type.is_nil():

--- a/src/gene/stdlib/core.nim
+++ b/src/gene/stdlib/core.nim
@@ -137,8 +137,8 @@ proc value_class_value(val: Value): Value =
   of VkApplication:
     App.app.application_class
   of VkSet:
-    if App.app.set_class.kind == VkClass:
-      App.app.set_class
+    if App.app.hash_set_class.kind == VkClass:
+      App.app.hash_set_class
     else:
       App.app.object_class
   of VkFuture:
@@ -1573,17 +1573,6 @@ proc init_date_functions() =
   var tomorrow_fn = new_ref(VkNativeFn)
   tomorrow_fn.native_fn = gene_tomorrow_native
   App.app.gene_ns.ns["tomorrow".to_key()] = tomorrow_fn.to_ref_value()
-
-proc init_set_class(object_class: Class) =
-  var r: ptr Reference
-  let set_class = new_class("Set")
-  set_class.parent = object_class
-  set_class.def_native_method("to_s", object_to_s_method)
-  r = new_ref(VkClass)
-  r.class = set_class
-  App.app.set_class = r.to_ref_value()
-  App.app.gene_ns.ns["Set".to_key()] = App.app.set_class
-  App.app.global_ns.ns["Set".to_key()] = App.app.set_class
 
 proc init_gene_and_meta_classes(object_class: Class) =
   var r: ptr Reference
@@ -4037,7 +4026,7 @@ proc init_gene_namespace*() =
 
   stdlib_selectors.init_selector_class(object_class)
   
-  stdlib_collections.init_set_class(object_class)
+  stdlib_collections.init_hash_set_class(object_class)
   stdlib_gene_meta.init_gene_and_meta_classes(object_class)
 
   init_gene_core_functions()

--- a/src/gene/types/classes.nim
+++ b/src/gene/types/classes.nim
@@ -147,7 +147,7 @@ proc get_class*(val: Value): Class {.inline.} =
     of VkHashMap:
       return App.ref.app.hash_map_class.ref.class
     of VkSet:
-      return App.ref.app.set_class.ref.class
+      return App.ref.app.hash_set_class.ref.class
     of VkGene:
       return App.ref.app.gene_class.ref.class
     of VkRegex:

--- a/src/gene/types/core/constructors.nim
+++ b/src/gene/types/core/constructors.nim
@@ -1,4 +1,4 @@
-## Int, String, ComplexSymbol, Array, Stream, Set, Map, Instance,
+## Int, String, ComplexSymbol, Array, Stream, HashSet, Map, Instance,
 ## Range, Regex, Date/DateTime/Time, Selector, SourceTrace, Gene constructors.
 ## Included from core.nim — shares its scope.
 
@@ -183,7 +183,7 @@ proc new_stream_value*(v: varargs[Value]): Value =
   r.stream = @v
   result = r.to_ref_value()
 
-#################### Set #########################
+#################### HashSet #####################
 
 proc new_set_value*(): Value =
   let r = new_ref(VkSet)

--- a/src/gene/types/core/constructors.nim
+++ b/src/gene/types/core/constructors.nim
@@ -162,7 +162,7 @@ proc len*(self: Value): int =
   of VkHashMap:
     return self.ref.hash_map_items.len div 2
   of VkSet:
-    return self.ref.set.len
+    return self.ref.set_items.len
   of VkGene:
     return self.gene.children.len
   of VkRange:
@@ -187,6 +187,14 @@ proc new_stream_value*(v: varargs[Value]): Value =
 
 proc new_set_value*(): Value =
   let r = new_ref(VkSet)
+  r.set_items = @[]
+  r.set_buckets = initOrderedTable[Hash, seq[int]]()
+  result = r.to_ref_value()
+
+proc new_set_value*(items: seq[Value]): Value =
+  let r = new_ref(VkSet)
+  r.set_items = items
+  r.set_buckets = initOrderedTable[Hash, seq[int]]()
   result = r.to_ref_value()
 
 #################### Map #########################

--- a/src/gene/types/core/value_ops.nim
+++ b/src/gene/types/core/value_ops.nim
@@ -201,7 +201,19 @@ proc `==`*(a, b: ptr Reference): bool =
     of VkInt:
       return a.int_data == b.int_data
     of VkSet:
-      return a.set == b.set
+      let items1 = a.set_items
+      let items2 = b.set_items
+      if items1.len != items2.len:
+        return false
+      for item1 in items1:
+        var found = false
+        for item2 in items2:
+          if item1 == item2:
+            found = true
+            break
+        if not found:
+          return false
+      return true
     of VkComplexSymbol:
       return a.csymbol == b.csymbol
     else:
@@ -238,6 +250,12 @@ template hash_map_items*(v: Value): var seq[Value] =
 
 template hash_map_buckets*(v: Value): var OrderedTable[Hash, seq[int]] =
   `ref`(v).hash_map_buckets
+
+template hash_set_items*(v: Value): var seq[Value] =
+  `ref`(v).set_items
+
+template hash_set_buckets*(v: Value): var OrderedTable[Hash, seq[int]] =
+  `ref`(v).set_buckets
 
 proc hash_map_is_frozen*(v: Value): bool {.inline, gcsafe, noSideEffect.} =
   let u = cast[uint64](v)
@@ -314,6 +332,20 @@ proc `==`*(a, b: Value): bool {.gcsafe, noSideEffect.} =
           if items1[i] != items2[i] or items1[i + 1] != items2[i + 1]:
             return false
           i += 2
+        return true
+      elif tag1 == REF_TAG and tag2 == REF_TAG and a.ref.kind == VkSet and b.ref.kind == VkSet:
+        let items1 = a.ref.set_items
+        let items2 = b.ref.set_items
+        if items1.len != items2.len:
+          return false
+        for item1 in items1:
+          var found = false
+          for item2 in items2:
+            if item1 == item2:
+              found = true
+              break
+          if not found:
+            return false
         return true
       # Arrays compare structurally
       elif tag1 == ARRAY_TAG and tag2 == ARRAY_TAG:
@@ -523,7 +555,10 @@ proc str_no_quotes*(self: Value): string {.gcsafe.} =
           result &= v.str_no_quotes()
         result &= "]"
       of VkSet:
-        result = "unsupported"
+        result = "(HashSet"
+        for item in self.ref.set_items:
+          result &= " " & item.str_no_quotes()
+        result &= ")"
       of VkMap:
         result = if map_is_frozen(self): "#{" else: "{"
         var first = true
@@ -620,7 +655,10 @@ proc `$`*(self: Value): string {.gcsafe.} =
           result &= $v
         result &= "]"
       of VkSet:
-        result = "unsupported"
+        result = "(HashSet"
+        for item in self.ref.set_items:
+          result &= " " & $item
+        result &= ")"
       of VkMap:
         result = if map_is_frozen(self): "#{" else: "{"
         var first = true
@@ -841,7 +879,7 @@ proc size*(self: Value): int =
           of VkHashMap:
             return r.hash_map_items.len div 2
           of VkSet:
-            return r.set.len
+            return r.set_items.len
           of VkMap:
             return r.map.len
           of VkString:

--- a/src/gene/types/memory.nim
+++ b/src/gene/types/memory.nim
@@ -176,7 +176,7 @@ proc `=default`*(v: var Value) {.inline.} =
   ## This ensures no uninitialized garbage, making =copy safe
   v.raw = 0
 
-proc `=destroy`*(v: var Value) =
+proc `=destroy`*(v: Value) =
   ## Called when Value goes out of scope
   ## Decrements ref count for managed types
   if isManaged(v):

--- a/src/gene/types/reference_types.nim
+++ b/src/gene/types/reference_types.nim
@@ -82,7 +82,8 @@ type
 
       # Collection types
       of VkSet:
-        set*: HashSet[Value]
+        set_items*: seq[Value]
+        set_buckets*: OrderedTable[Hash, seq[int]]
       of VkMap:
         map*: Table[Key, Value]
       of VkHashMap:

--- a/src/gene/types/runtime_types.nim
+++ b/src/gene/types/runtime_types.nim
@@ -255,6 +255,7 @@ proc runtime_type_name*(v: Value): string =
   of VkArray: "Array"
   of VkMap: "Map"
   of VkHashMap: "HashMap"
+  of VkSet: "HashSet"
   of VkInstance:
     # For instances, try to get the class name
     let inst = cast[ptr InstanceObj](v.raw and PAYLOAD_MASK)
@@ -291,6 +292,8 @@ proc is_named_compatible(value: Value, expected_type: string): bool =
   let actual = runtime_type_name(value)
   if actual == expected_type:
     return true
+  if actual == "HashSet" and expected_type == "Set":
+    return true
   let adt = adt_type_name(value)
   if adt.len > 0 and adt == expected_type:
     return true
@@ -298,7 +301,7 @@ proc is_named_compatible(value: Value, expected_type: string): bool =
   of "Numeric":
     return actual in ["Int", "Float"]
   of "Collection":
-    return actual in ["Array", "Map", "HashMap", "Set"]
+    return actual in ["Array", "Map", "HashMap", "HashSet", "Set"]
   of "Function":
     return value.kind in {VkFunction, VkBlock, VkNativeFn}
   else:

--- a/src/gene/types/runtime_types.nim
+++ b/src/gene/types/runtime_types.nim
@@ -292,8 +292,6 @@ proc is_named_compatible(value: Value, expected_type: string): bool =
   let actual = runtime_type_name(value)
   if actual == expected_type:
     return true
-  if actual == "HashSet" and expected_type == "Set":
-    return true
   let adt = adt_type_name(value)
   if adt.len > 0 and adt == expected_type:
     return true
@@ -301,7 +299,7 @@ proc is_named_compatible(value: Value, expected_type: string): bool =
   of "Numeric":
     return actual in ["Int", "Float"]
   of "Collection":
-    return actual in ["Array", "Map", "HashMap", "HashSet", "Set"]
+    return actual in ["Array", "Map", "HashMap", "HashSet"]
   of "Function":
     return value.kind in {VkFunction, VkBlock, VkNativeFn}
   else:

--- a/src/gene/types/type_defs.nim
+++ b/src/gene/types/type_defs.nim
@@ -391,7 +391,7 @@ type
     array_class*    : Value
     map_class*      : Value
     hash_map_class* : Value
-    set_class*      : Value
+    hash_set_class* : Value
     gene_class*     : Value
     stream_class*   : Value
     document_class* : Value

--- a/src/gene/vm/core_helpers.nim
+++ b/src/gene/vm/core_helpers.nim
@@ -295,7 +295,7 @@ template get_value_class(val: Value): Class =
   of VkDateTime:
     safe_class_value(App.app.datetime_class)
   of VkSet:
-    safe_class_value(App.app.set_class)
+    safe_class_value(App.app.hash_set_class)
   of VkSelector:
     safe_class_value(App.app.selector_class)
   of VkRegex:

--- a/src/gene/vm/exec.nim
+++ b/src/gene/vm/exec.nim
@@ -3917,7 +3917,7 @@ proc exec*(self: ptr VirtualMachine): Value =
         of VkGene:
           class_val = App.app.gene_class
         of VkSet:
-          class_val = App.app.set_class
+          class_val = App.app.hash_set_class
         of VkTime:
           class_val = App.app.time_class
         of VkDate:

--- a/tests/integration/test_exception.nim
+++ b/tests/integration/test_exception.nim
@@ -1,8 +1,10 @@
 import std/json
 import unittest
 
+import gene/error_display
 import gene/types except Exception
 import gene/vm
+import gene/vm/diagnostics
 
 import ../helpers
 
@@ -299,3 +301,10 @@ test "runtime exception produces structured diagnostic envelope":
     check parsed.hasKey("span")
     check parsed["span"].hasKey("line")
     check parsed["code"].getStr().len > 0
+
+test "render_error_message preserves canonical diagnostic field order":
+  let rendered = render_error_message(diagnostics.make_diagnostic_message(
+    "GENE.RUNTIME.ERROR",
+    "boom"
+  ))
+  check rendered == "{^message \"boom\" ^code \"GENE.RUNTIME.ERROR\" ^severity \"error\" ^stage \"runtime\" ^span {^file \"\" ^line 0 ^column 0} ^hints [] ^repair_tags [\"runtime\"]}"

--- a/tests/integration/test_hash_map.nim
+++ b/tests/integration/test_hash_map.nim
@@ -125,3 +125,10 @@ suite "HashMap":
     except CatchableError as e:
       check e.msg.contains("not hashable for HashMap")
 
+  test_vm """
+    (do
+      (var m {{[1 2] "pair" 1 "one"}})
+      (m .delete 1)
+      (m .get [1 2])
+    )
+  """, "pair"

--- a/tests/integration/test_hash_set.nim
+++ b/tests/integration/test_hash_set.nim
@@ -1,0 +1,109 @@
+import unittest
+import strutils
+
+import gene/types except Exception
+import gene/vm
+
+import ../helpers
+
+suite "HashSet":
+  test_vm """
+    (do
+      (var s (new HashSet 1 "two" [3 4] [3 4]))
+      [(s .has 1) (s .has "two") (s .has [3 4]) (s .size)]
+    )
+  """, proc(result: Value) =
+    check result.kind == VkArray
+    check array_data(result) == @[TRUE, TRUE, TRUE, 3.to_value()]
+
+  test_vm """
+    (do
+      (var s (new HashSet 1 2))
+      (s .add 3 3)
+      [(s .contains 3) (s .delete 2) (s .size) (s .delete 9) (do (s .clear) (s .size))]
+    )
+  """, proc(result: Value) =
+    check result.kind == VkArray
+    check array_data(result)[0] == TRUE
+    check array_data(result)[1] == 2.to_value()
+    check array_data(result)[2] == 2.to_value()
+    check array_data(result)[3] == NIL
+    check array_data(result)[4] == 0.to_value()
+
+  test_vm """
+    (do
+      (var sum 0)
+      (for x in (new HashSet 1 2 3)
+        (sum += x)
+      )
+      sum
+    )
+  """, 6
+
+  test_vm """
+    (do
+      (var a (new HashSet 1 2 3))
+      (var b (new HashSet 3 4))
+      [((a .union b) .to_array) ((a .intersect b) .to_array) ((a .diff b) .to_array) ((new HashSet 1 2) .subset? a)]
+    )
+  """, proc(result: Value) =
+    check result.kind == VkArray
+    check array_data(array_data(result)[0]) == @[1.to_value(), 2.to_value(), 3.to_value(), 4.to_value()]
+    check array_data(array_data(result)[1]) == @[3.to_value()]
+    check array_data(array_data(result)[2]) == @[1.to_value(), 2.to_value()]
+    check array_data(result)[3] == TRUE
+
+  test_vm """
+    (do
+      (class Key
+        (ctor [id]
+          (/id = id)
+        )
+        (method hash [] /id)
+      )
+      (var key (new Key 7))
+      (var s (new HashSet key))
+      (s .has key)
+    )
+  """, TRUE
+
+  test_vm """
+    (do
+      (class BadKey
+        (ctor [id]
+          (/id = id)
+        )
+        (method hash [] 1)
+      )
+      (var k1 (new BadKey 1))
+      (var k2 (new BadKey 2))
+      (var s (new HashSet k1 k2))
+      [(s .has k1) (s .has k2) (s .size)]
+    )
+  """, proc(result: Value) =
+    check result.kind == VkArray
+    check array_data(result)[0] == TRUE
+    check array_data(result)[1] == TRUE
+    check array_data(result)[2] == 2.to_value()
+
+  test_vm """
+    ((new HashSet 1 "two") .to_s)
+  """, "(HashSet 1 \"two\")"
+
+  test "unhashable objects are rejected":
+    init_all()
+    try:
+      discard VM.exec("""
+        (do
+          (class NoHash
+            (ctor []
+              nil
+            )
+          )
+          (var item (new NoHash))
+          (new HashSet item)
+        )
+      """, "hash_set_unhashable.gene")
+      fail()
+    except CatchableError as e:
+      check e.msg.contains("not hashable for HashSet")

--- a/tests/test_types.nim
+++ b/tests/test_types.nim
@@ -88,11 +88,11 @@ test "Array":
   check a[0] == 1
   check a[1] == NIL
 
-test "Set display is unsupported":
+test "HashSet display uses constructor syntax":
   let s = new_set_value()
   check s.kind == VkSet
-  check s.str_no_quotes() == "unsupported"
-  check $s == "unsupported"
+  check s.str_no_quotes() == "(HashSet)"
+  check $s == "(HashSet)"
 
 test "Frozen gene display":
   var gene_ptr = new_frozen_gene(1.to_value())

--- a/testsuite/06-collections/maps/5_hash_sets.gene
+++ b/testsuite/06-collections/maps/5_hash_sets.gene
@@ -1,0 +1,31 @@
+# Expected: true
+# Expected: 3
+# Expected: 2
+# Expected: 6
+# Expected: [1 2 3 4]
+# Expected: [3]
+# Expected: [1 2]
+# Expected: true
+# Expected: (HashSet 1 "two")
+
+(var s (new HashSet 1 "two" [3 4] [3 4]))
+(println (s .has [3 4]))
+(println (s .size))
+
+(s .add 2)
+(println (s .delete 2))
+
+(var sum 0)
+(for x in (new HashSet 1 2 3)
+  (sum += x)
+)
+(println sum)
+
+(var a (new HashSet 1 2 3))
+(var b (new HashSet 3 4))
+(println ((a .union b) .to_array))
+(println ((a .intersect b) .to_array))
+(println ((a .diff b) .to_array))
+(println ((new HashSet 1 2) .subset? a))
+
+(println ((new HashSet 1 "two") .to_s))


### PR DESCRIPTION
## Changes
- Fix linker error on Linux x86_64: replace `__builtin___clear_cache` with platform-specific cache flush (macOS: sys_icache_invalidate, Linux x86_64: no-op, Linux ARM: keep builtin)
- Fix deprecated Nim `=destroy` hook signature (`var T` → `T`)

## CI Issue
The GitHub Actions build was failing with:
```
undefined reference to `__builtin___clear_cache`
```
This builtin isn't available on x86_64 Linux GCC. Since x86_64 maintains instruction cache coherency in hardware, the flush is a no-op there.

## Testing
- All 249 `nimble test` tests pass on macOS ARM64
- Build succeeds locally