### PR TITLE
Add read cache for caller-saved registers in ARM64 codegen

### DIFF
--- a/benchmarks/computation/fibonacci_compare.nim
+++ b/benchmarks/computation/fibonacci_compare.nim
@@ -1,0 +1,84 @@
+## Fibonacci benchmark: VM interpreter vs native compilation side-by-side.
+## Runs fib(30) in both modes and prints a comparison table.
+
+when isMainModule:
+  import times, os, strformat
+
+  import ../../src/gene/types
+  import ../../src/gene/parser
+  import ../../src/gene/compiler
+  import ../../src/gene/vm
+
+  var n = "30"
+  let args = command_line_params()
+  if args.len > 0:
+    n = args[0]
+
+  # ── VM interpreter path (untyped, native disabled) ──
+  init_app_and_vm()
+  VM.native_code = false
+
+  let vm_code = fmt"""
+    (fn fib [n]
+      (if (< n 2)
+        then n
+        else (+ (fib (- n 1)) (fib (- n 2)))))
+    (fib {n})
+  """
+
+  let vm_compiled = compile(read_all(vm_code))
+  let vm_ns = new_namespace("fibonacci_vm")
+  VM.frame.update(new_frame(vm_ns))
+  VM.cu = vm_compiled
+  VM.trace = false
+
+  let vm_start = cpuTime()
+  let vm_result = VM.exec()
+  let vm_duration = cpuTime() - vm_start
+
+  let vm_int_result =
+    case vm_result.kind
+    of VkInt: vm_result.to_int()
+    of VkFloat: vm_result.to_float().int
+    else: 0
+
+  # ── Native compilation path (typed, native enabled) ──
+  init_app_and_vm()
+  VM.native_code = true
+
+  let native_code = fmt"""
+    (fn fib [n: Int] -> Int
+      (if (<= n 1)
+        n
+      else
+        (+ (fib (- n 1)) (fib (- n 2)))))
+    (fib {n})
+  """
+
+  let native_compiled = compile(read_all(native_code))
+  let native_ns = new_namespace("fibonacci_native")
+  VM.frame.update(new_frame(native_ns))
+  VM.cu = native_compiled
+  VM.trace = false
+
+  let native_start = cpuTime()
+  let native_result = VM.exec()
+  let native_duration = cpuTime() - native_start
+
+  let native_int_result =
+    case native_result.kind
+    of VkInt: native_result.to_int()
+    of VkFloat: native_result.to_float().int
+    else: 0
+
+  # ── Results ──
+  echo fmt"=== Fibonacci({n}) Comparison ==="
+  echo ""
+  echo fmt"  VM interpreter:      {vm_duration:.6f}s  result={vm_int_result}"
+  echo fmt"  Native compilation:  {native_duration:.6f}s  result={native_int_result}"
+  echo ""
+  if native_duration > 0:
+    let speedup = vm_duration / native_duration
+    echo fmt"  Speedup: {speedup:.2f}x"
+  if vm_int_result != native_int_result:
+    echo "  WARNING: results differ!"

--- a/src/gene/native/arm64_codegen.nim
+++ b/src/gene/native/arm64_codegen.nim
@@ -50,6 +50,8 @@ type
     callArgBaseOffset*: int32
     callArgSlots*: int32
     ctxSaveOffset*: int32
+    # Read cache: caller-saved X9-X15 map to HIR registers (-1 = empty)
+    readCache*: array[7, int32]
 
 const
   INSN_STP_FP_LR = 0xA9BF7BFD'u32  # stp x29, x30, [sp, #-16]!
@@ -397,7 +399,9 @@ proc newCodegenContext*(fn: HirFunction): CodegenContext =
     recursiveCallFixups: @[],
     callArgBaseOffset: 0,
     callArgSlots: 0,
-    ctxSaveOffset: 0
+    ctxSaveOffset: 0,
+    readCache: [CACHE_EMPTY, CACHE_EMPTY, CACHE_EMPTY, CACHE_EMPTY,
+                CACHE_EMPTY, CACHE_EMPTY, CACHE_EMPTY]
   )
 
   for i in 0..<fn.regCount:
@@ -432,124 +436,183 @@ proc storeRegF64*(ctx: CodegenContext, hirReg: HirReg, src: DReg) =
   ## Store FP D-register to HIR register on stack
   ctx.buf.emitFStr(src, ctx.regOffset(hirReg))
 
+const
+  CACHE_REGS = [X9, X10, X11, X12, X13, X14, X15]
+  CACHE_EMPTY = -1'i32
+
+proc invalidateCache*(ctx: CodegenContext) {.inline.} =
+  for i in 0..<ctx.readCache.len:
+    ctx.readCache[i] = CACHE_EMPTY
+
+proc cacheFind(ctx: CodegenContext, hirReg: HirReg): int {.inline.} =
+  ## Returns cache slot index if hirReg is cached, -1 otherwise.
+  let r = int32(hirReg)
+  for i in 0..<ctx.readCache.len:
+    if ctx.readCache[i] == r:
+      return i
+  return -1
+
+proc cacheAllocSlot(ctx: CodegenContext): int {.inline.} =
+  ## Find a free cache slot, or evict slot 0 (simple round-robin).
+  for i in 0..<ctx.readCache.len:
+    if ctx.readCache[i] == CACHE_EMPTY:
+      return i
+  return 0  # evict first slot (no dirty tracking needed — write-through)
+
+proc cachedLoad*(ctx: CodegenContext, dst: Arm64Reg, hirReg: HirReg) =
+  ## Load HIR register into dst, using cache if available.
+  let slot = ctx.cacheFind(hirReg)
+  if slot >= 0:
+    # Cache hit: mov dst, cacheReg
+    ctx.buf.emitMovRegReg(dst, CACHE_REGS[slot])
+  else:
+    # Cache miss: load from stack
+    ctx.buf.emitLdrReg(dst, ctx.regOffset(hirReg))
+    # Populate cache
+    let s = ctx.cacheAllocSlot()
+    ctx.readCache[s] = int32(hirReg)
+    ctx.buf.emitMovRegReg(CACHE_REGS[s], dst)
+
+proc cachedStore*(ctx: CodegenContext, hirReg: HirReg, src: Arm64Reg) =
+  ## Store src to HIR register on stack (write-through) and update cache.
+  ctx.buf.emitStrReg(src, ctx.regOffset(hirReg))
+  # Update or populate cache entry
+  var slot = ctx.cacheFind(hirReg)
+  if slot < 0:
+    slot = ctx.cacheAllocSlot()
+  ctx.readCache[slot] = int32(hirReg)
+  ctx.buf.emitMovRegReg(CACHE_REGS[slot], src)
+
+proc cacheInvalidateReg*(ctx: CodegenContext, hirReg: HirReg) {.inline.} =
+  ## Remove a specific HIR register from cache (e.g. after overwrite by FP op).
+  let slot = ctx.cacheFind(hirReg)
+  if slot >= 0:
+    ctx.readCache[slot] = CACHE_EMPTY
+
 proc genOp*(ctx: CodegenContext, op: HirOp)
 
 proc genConstI64*(ctx: CodegenContext, op: HirOp) =
   ctx.buf.emitMovImm64(X0, op.constI64)
-  ctx.storeReg(op.dest, X0)
+  ctx.cachedStore(op.dest, X0)
 
 proc genAddI64*(ctx: CodegenContext, op: HirOp) =
-  ctx.loadReg(X0, op.binLeft)
-  ctx.loadReg(X1, op.binRight)
+  ctx.cachedLoad(X0, op.binLeft)
+  ctx.cachedLoad(X1, op.binRight)
   ctx.buf.emitAddRegReg(X0, X0, X1)
-  ctx.storeReg(op.dest, X0)
+  ctx.cachedStore(op.dest, X0)
 
 proc genSubI64*(ctx: CodegenContext, op: HirOp) =
-  ctx.loadReg(X0, op.binLeft)
-  ctx.loadReg(X1, op.binRight)
+  ctx.cachedLoad(X0, op.binLeft)
+  ctx.cachedLoad(X1, op.binRight)
   ctx.buf.emitSubRegReg(X0, X0, X1)
-  ctx.storeReg(op.dest, X0)
+  ctx.cachedStore(op.dest, X0)
 
 proc genMulI64*(ctx: CodegenContext, op: HirOp) =
-  ctx.loadReg(X0, op.binLeft)
-  ctx.loadReg(X1, op.binRight)
+  ctx.cachedLoad(X0, op.binLeft)
+  ctx.cachedLoad(X1, op.binRight)
   ctx.buf.emitMulRegReg(X0, X0, X1)
-  ctx.storeReg(op.dest, X0)
+  ctx.cachedStore(op.dest, X0)
 
 proc genDivI64*(ctx: CodegenContext, op: HirOp) =
-  ctx.loadReg(X0, op.binLeft)
-  ctx.loadReg(X1, op.binRight)
+  ctx.cachedLoad(X0, op.binLeft)
+  ctx.cachedLoad(X1, op.binRight)
   ctx.buf.emitSdivRegReg(X0, X0, X1)
-  ctx.storeReg(op.dest, X0)
+  ctx.cachedStore(op.dest, X0)
 
 proc genModI64*(ctx: CodegenContext, op: HirOp) =
-  ctx.loadReg(X0, op.binLeft)
-  ctx.loadReg(X1, op.binRight)
+  ctx.cachedLoad(X0, op.binLeft)
+  ctx.cachedLoad(X1, op.binRight)
   ctx.buf.emitSdivRegReg(X2, X0, X1)
   ctx.buf.emitMsubRegRegReg(X0, X2, X1, X0)
-  ctx.storeReg(op.dest, X0)
+  ctx.cachedStore(op.dest, X0)
 
 proc genNegI64*(ctx: CodegenContext, op: HirOp) =
-  ctx.loadReg(X0, op.unaryArg)
+  ctx.cachedLoad(X0, op.unaryArg)
   ctx.buf.emitNegReg(X0, X0)
-  ctx.storeReg(op.dest, X0)
+  ctx.cachedStore(op.dest, X0)
 
 proc genLeI64*(ctx: CodegenContext, op: HirOp) =
-  ctx.loadReg(X0, op.binLeft)
-  ctx.loadReg(X1, op.binRight)
+  ctx.cachedLoad(X0, op.binLeft)
+  ctx.cachedLoad(X1, op.binRight)
   ctx.buf.emitCmpRegReg(X0, X1)
   ctx.buf.emitCsetLe(X0)
-  ctx.storeReg(op.dest, X0)
+  ctx.cachedStore(op.dest, X0)
 
 proc genLtI64*(ctx: CodegenContext, op: HirOp) =
-  ctx.loadReg(X0, op.binLeft)
-  ctx.loadReg(X1, op.binRight)
+  ctx.cachedLoad(X0, op.binLeft)
+  ctx.cachedLoad(X1, op.binRight)
   ctx.buf.emitCmpRegReg(X0, X1)
   ctx.buf.emitCsetLt(X0)
-  ctx.storeReg(op.dest, X0)
+  ctx.cachedStore(op.dest, X0)
 
 proc genGeI64*(ctx: CodegenContext, op: HirOp) =
-  ctx.loadReg(X0, op.binLeft)
-  ctx.loadReg(X1, op.binRight)
+  ctx.cachedLoad(X0, op.binLeft)
+  ctx.cachedLoad(X1, op.binRight)
   ctx.buf.emitCmpRegReg(X0, X1)
   ctx.buf.emitCsetGe(X0)
-  ctx.storeReg(op.dest, X0)
+  ctx.cachedStore(op.dest, X0)
 
 proc genGtI64*(ctx: CodegenContext, op: HirOp) =
-  ctx.loadReg(X0, op.binLeft)
-  ctx.loadReg(X1, op.binRight)
+  ctx.cachedLoad(X0, op.binLeft)
+  ctx.cachedLoad(X1, op.binRight)
   ctx.buf.emitCmpRegReg(X0, X1)
   ctx.buf.emitCsetGt(X0)
-  ctx.storeReg(op.dest, X0)
+  ctx.cachedStore(op.dest, X0)
 
 proc genEqI64*(ctx: CodegenContext, op: HirOp) =
-  ctx.loadReg(X0, op.binLeft)
-  ctx.loadReg(X1, op.binRight)
+  ctx.cachedLoad(X0, op.binLeft)
+  ctx.cachedLoad(X1, op.binRight)
   ctx.buf.emitCmpRegReg(X0, X1)
   ctx.buf.emitCsetEq(X0)
-  ctx.storeReg(op.dest, X0)
+  ctx.cachedStore(op.dest, X0)
 
 proc genNeI64*(ctx: CodegenContext, op: HirOp) =
-  ctx.loadReg(X0, op.binLeft)
-  ctx.loadReg(X1, op.binRight)
+  ctx.cachedLoad(X0, op.binLeft)
+  ctx.cachedLoad(X1, op.binRight)
   ctx.buf.emitCmpRegReg(X0, X1)
   ctx.buf.emitCsetNe(X0)
-  ctx.storeReg(op.dest, X0)
+  ctx.cachedStore(op.dest, X0)
 
 proc genConstF64*(ctx: CodegenContext, op: HirOp) =
   ## Load float64 constant: movimm64 → GPR, fmov GPR → D-reg, store
   ctx.buf.emitMovImm64(X0, cast[int64](op.constF64))
   ctx.buf.emitFmovFromGpr(D0, X0)
   ctx.storeRegF64(op.dest, D0)
+  ctx.cacheInvalidateReg(op.dest)
 
 proc genAddF64*(ctx: CodegenContext, op: HirOp) =
   ctx.loadRegF64(D0, op.binLeft)
   ctx.loadRegF64(D1, op.binRight)
   ctx.buf.emitFadd(D0, D0, D1)
   ctx.storeRegF64(op.dest, D0)
+  ctx.cacheInvalidateReg(op.dest)
 
 proc genSubF64*(ctx: CodegenContext, op: HirOp) =
   ctx.loadRegF64(D0, op.binLeft)
   ctx.loadRegF64(D1, op.binRight)
   ctx.buf.emitFsub(D0, D0, D1)
   ctx.storeRegF64(op.dest, D0)
+  ctx.cacheInvalidateReg(op.dest)
 
 proc genMulF64*(ctx: CodegenContext, op: HirOp) =
   ctx.loadRegF64(D0, op.binLeft)
   ctx.loadRegF64(D1, op.binRight)
   ctx.buf.emitFmul(D0, D0, D1)
   ctx.storeRegF64(op.dest, D0)
+  ctx.cacheInvalidateReg(op.dest)
 
 proc genDivF64*(ctx: CodegenContext, op: HirOp) =
   ctx.loadRegF64(D0, op.binLeft)
   ctx.loadRegF64(D1, op.binRight)
   ctx.buf.emitFdiv(D0, D0, D1)
   ctx.storeRegF64(op.dest, D0)
+  ctx.cacheInvalidateReg(op.dest)
 
 proc genModF64*(ctx: CodegenContext, op: HirOp) =
   ctx.loadRegF64(D0, op.binLeft)
   ctx.loadRegF64(D1, op.binRight)
   ctx.buf.emitMovImm64(X8, cast[int64](cast[pointer](c_fmod)))
+  ctx.invalidateCache()  # blr clobbers caller-saved regs
   ctx.buf.emitBlr(X8)
   ctx.storeRegF64(op.dest, D0)
 
@@ -557,64 +620,66 @@ proc genNegF64*(ctx: CodegenContext, op: HirOp) =
   ctx.loadRegF64(D0, op.unaryArg)
   ctx.buf.emitFneg(D0, D0)
   ctx.storeRegF64(op.dest, D0)
+  ctx.cacheInvalidateReg(op.dest)
 
 proc genLeF64*(ctx: CodegenContext, op: HirOp) =
   ctx.loadRegF64(D0, op.binLeft)
   ctx.loadRegF64(D1, op.binRight)
   ctx.buf.emitFcmp(D0, D1)
   ctx.buf.emitCsetFloatLe(X0)
-  ctx.storeReg(op.dest, X0)
+  ctx.cachedStore(op.dest, X0)
 
 proc genLtF64*(ctx: CodegenContext, op: HirOp) =
   ctx.loadRegF64(D0, op.binLeft)
   ctx.loadRegF64(D1, op.binRight)
   ctx.buf.emitFcmp(D0, D1)
   ctx.buf.emitCsetFloatLt(X0)
-  ctx.storeReg(op.dest, X0)
+  ctx.cachedStore(op.dest, X0)
 
 proc genGeF64*(ctx: CodegenContext, op: HirOp) =
   ctx.loadRegF64(D0, op.binLeft)
   ctx.loadRegF64(D1, op.binRight)
   ctx.buf.emitFcmp(D0, D1)
   ctx.buf.emitCsetFloatGe(X0)
-  ctx.storeReg(op.dest, X0)
+  ctx.cachedStore(op.dest, X0)
 
 proc genGtF64*(ctx: CodegenContext, op: HirOp) =
   ctx.loadRegF64(D0, op.binLeft)
   ctx.loadRegF64(D1, op.binRight)
   ctx.buf.emitFcmp(D0, D1)
   ctx.buf.emitCsetFloatGt(X0)
-  ctx.storeReg(op.dest, X0)
+  ctx.cachedStore(op.dest, X0)
 
 proc genEqF64*(ctx: CodegenContext, op: HirOp) =
   ctx.loadRegF64(D0, op.binLeft)
   ctx.loadRegF64(D1, op.binRight)
   ctx.buf.emitFcmp(D0, D1)
   ctx.buf.emitCsetFloatEq(X0)
-  ctx.storeReg(op.dest, X0)
+  ctx.cachedStore(op.dest, X0)
 
 proc genNeF64*(ctx: CodegenContext, op: HirOp) =
   ctx.loadRegF64(D0, op.binLeft)
   ctx.loadRegF64(D1, op.binRight)
   ctx.buf.emitFcmp(D0, D1)
   ctx.buf.emitCsetFloatNe(X0)
-  ctx.storeReg(op.dest, X0)
+  ctx.cachedStore(op.dest, X0)
 
 proc genBr*(ctx: CodegenContext, op: HirOp) =
-  ctx.loadReg(X0, op.brCond)
+  ctx.cachedLoad(X0, op.brCond)
+  ctx.invalidateCache()  # Control flow boundary
   ctx.buf.emitCbz(X0, op.brElse)
   ctx.buf.emitB(op.brThen)
 
 proc genJump*(ctx: CodegenContext, op: HirOp) =
+  ctx.invalidateCache()  # Control flow boundary
   ctx.buf.emitB(op.jumpTarget)
 
 proc genRet*(ctx: CodegenContext, op: HirOp) =
   if ctx.fn.returnType == HtF64:
-    # Load float, bitcast to int64 for uniform ABI return
     ctx.loadRegF64(D0, op.retValue)
     ctx.buf.emitFmovToGpr(X0, D0)
   else:
-    ctx.loadReg(X0, op.retValue)
+    ctx.cachedLoad(X0, op.retValue)
   ctx.buf.emitLdrReg(X19, ctx.ctxSaveOffset)
   if ctx.stackSize > 0:
     ctx.buf.emitAddSpImm(ctx.stackSize)
@@ -627,23 +692,25 @@ proc genCall*(ctx: CodegenContext, op: HirOp) =
     raise newException(ValueError, "Too many arguments for native call: " & $op.callArgs.len)
   ctx.buf.emitMovRegReg(X0, X19)
   for i in 0..<op.callArgs.len:
-    ctx.loadReg(argRegs[i], op.callArgs[i])
+    ctx.cachedLoad(argRegs[i], op.callArgs[i])
   if op.callTarget != ctx.fn.name:
     raise newException(ValueError, "External native calls not supported: " & op.callTarget)
+  ctx.invalidateCache()  # bl clobbers caller-saved regs
   let offset = ctx.buf.currentOffset()
   ctx.buf.emitU32(0x9400_0000'u32)  # bl placeholder
   ctx.recursiveCallFixups.add(offset)
-  ctx.storeReg(op.dest, X0)
+  ctx.cachedStore(op.dest, X0)
 
 proc genCallVM*(ctx: CodegenContext, op: HirOp) =
   if op.callVmArgs.len > ctx.callArgSlots:
     raise newException(ValueError, "Too many arguments for trampoline call: " & $op.callVmArgs.len)
 
   for i in 0..<op.callVmArgs.len:
-    ctx.loadReg(X0, op.callVmArgs[i])
+    ctx.cachedLoad(X0, op.callVmArgs[i])
     let offset = ctx.callArgBaseOffset + int32(i) * 8
     ctx.buf.emitStrReg(X0, offset)
 
+  ctx.invalidateCache()  # blr clobbers caller-saved regs
   ctx.buf.emitMovRegReg(X0, X19)
   ctx.buf.emitMovImm64(X1, op.callVmDescIdx.int64)
   ctx.buf.emitAddRegImm(X2, SP, ctx.callArgBaseOffset)
@@ -651,19 +718,19 @@ proc genCallVM*(ctx: CodegenContext, op: HirOp) =
   ctx.buf.emitLdrRegBase(X8, X19, NativeCtxOffsetTrampoline)
   ctx.buf.emitBlr(X8)
 
-  ctx.storeReg(op.dest, X0)
+  ctx.cachedStore(op.dest, X0)
 
 proc genBoxString*(ctx: CodegenContext, op: HirOp) =
-  ctx.loadReg(X0, op.unaryArg)
+  ctx.cachedLoad(X0, op.unaryArg)
   ctx.buf.emitMovImm64(X1, cast[int64](STRING_TAG_U64))
   ctx.buf.emitOrrRegReg(X0, X0, X1)
-  ctx.storeReg(op.dest, X0)
+  ctx.cachedStore(op.dest, X0)
 
 proc genUnboxString*(ctx: CodegenContext, op: HirOp) =
-  ctx.loadReg(X0, op.unaryArg)
+  ctx.cachedLoad(X0, op.unaryArg)
   ctx.buf.emitMovImm64(X1, cast[int64](PAYLOAD_MASK_U64))
   ctx.buf.emitAndRegReg(X0, X0, X1)
-  ctx.storeReg(op.dest, X0)
+  ctx.cachedStore(op.dest, X0)
 
 proc genOp*(ctx: CodegenContext, op: HirOp) =
   case op.kind
@@ -725,6 +792,7 @@ proc genPrologue*(ctx: CodegenContext) =
 
 proc genBlock*(ctx: CodegenContext, blk: HirBlock) =
   ctx.buf.markLabel(blk.id)
+  ctx.invalidateCache()  # Block boundary: predecessors may differ
   for op in blk.ops:
     ctx.genOp(op)
 

--- a/src/gene/vm/core_helpers.nim
+++ b/src/gene/vm/core_helpers.nim
@@ -156,6 +156,26 @@ proc native_args_supported(f: Function, args: seq[Value]): bool =
       return false
   true
 
+proc native_args_supported0(f: Function): bool {.inline.} =
+  if f.matcher.is_nil or not f.matcher.has_type_annotations:
+    return false
+  f.matcher.children.len == 0
+
+proc native_args_supported1(f: Function, arg: Value): bool {.inline.} =
+  if f.matcher.is_nil or not f.matcher.has_type_annotations:
+    return false
+  if f.matcher.children.len != 1:
+    return false
+  let tid = f.matcher.children[0].type_id
+  if tid == BUILTIN_TYPE_INT_ID:
+    return arg.kind == VkInt
+  elif tid == BUILTIN_TYPE_FLOAT_ID:
+    return arg.kind == VkFloat
+  elif tid == BUILTIN_TYPE_STRING_ID:
+    return arg.kind == VkString
+  else:
+    return false
+
 proc effective_native_tier(self: ptr VirtualMachine): NativeCompileTier {.inline.} =
   if self == nil:
     return NctNever
@@ -177,6 +197,26 @@ proc native_call_supported(self: ptr VirtualMachine, f: Function, args: seq[Valu
   if tier == NctNever:
     return false
   if not native_args_supported(f, args):
+    return false
+  if tier == NctFullyTyped and not native_has_fully_typed_boundary(f):
+    return false
+  true
+
+proc native_call_supported0(self: ptr VirtualMachine, f: Function): bool {.inline.} =
+  let tier = self.effective_native_tier()
+  if tier == NctNever:
+    return false
+  if not native_args_supported0(f):
+    return false
+  if tier == NctFullyTyped and not native_has_fully_typed_boundary(f):
+    return false
+  true
+
+proc native_call_supported1(self: ptr VirtualMachine, f: Function, arg: Value): bool {.inline.} =
+  let tier = self.effective_native_tier()
+  if tier == NctNever:
+    return false
+  if not native_args_supported1(f, arg):
     return false
   if tier == NctFullyTyped and not native_has_fully_typed_boundary(f):
     return false

--- a/src/gene/vm/exec.nim
+++ b/src/gene/vm/exec.nim
@@ -4532,7 +4532,7 @@ proc exec*(self: ptr VirtualMachine): Value =
             self.frame.push(new_generator_value(f, @[]))
           else:
             var native_result: Value
-            if self.try_native_call(f, @[], native_result):
+            if self.try_native_call0(f, native_result):
               self.frame.push(native_result)
             else:
               if f.body_compiled == nil:
@@ -4717,7 +4717,7 @@ proc exec*(self: ptr VirtualMachine): Value =
             self.frame.push(new_generator_value(f, @[arg]))
           else:
             var native_result: Value
-            if self.try_native_call(f, @[arg], native_result):
+            if self.try_native_call1(f, arg, native_result):
               self.frame.push(native_result)
             else:
               if f.body_compiled == nil:

--- a/src/gene/vm/native.nim
+++ b/src/gene/vm/native.nim
@@ -83,13 +83,10 @@ proc native_trampoline*(
     retain(result_val)
     return cast[int64](result_val.raw)
 
-proc try_native_call(self: ptr VirtualMachine, f: Function, args: seq[Value], out_value: var Value): bool =
-  if self.effective_native_tier() == NctNever:
-    return false
+proc prepare_native_ctx(self: ptr VirtualMachine, f: Function, out_ctx: var NativeContext): bool {.inline.} =
+  ## Shared preamble: ensure native code is compiled and set up NativeContext.
+  ## Returns false if native execution is not available for this function.
   if f.is_generator or f.async or f.is_macro_like:
-    return false
-  if not native_call_supported(self, f, args):
-    # Tier/guard miss deoptimizes this call to the VM bytecode path.
     return false
   if not f.native_ready:
     if f.native_failed:
@@ -104,55 +101,22 @@ proc try_native_call(self: ptr VirtualMachine, f: Function, args: seq[Value], ou
       release_descriptors(f.native_descriptors)
     f.native_entry = compiled.entry
     f.native_ready = true
-    # Determine if return value is float (from HIR inference or explicit annotation)
     f.native_return_float = compiled.returnFloat
     f.native_return_string = compiled.returnString
     f.native_return_value = compiled.returnValue
     f.native_descriptors = compiled.descriptors
 
-  var ctx = NativeContext(
+  out_ctx = NativeContext(
     vm: self,
     trampoline: cast[pointer](native_trampoline),
     descriptors: nil,
     descriptor_count: f.native_descriptors.len.int32
   )
   if f.native_descriptors.len > 0:
-    ctx.descriptors = cast[ptr UncheckedArray[CallDescriptor]](f.native_descriptors[0].addr)
+    out_ctx.descriptors = cast[ptr UncheckedArray[CallDescriptor]](f.native_descriptors[0].addr)
+  true
 
-  var marshaled_args: seq[system.int64] = newSeq[system.int64](args.len)
-  for i in 0..<args.len:
-    marshaled_args[i] = arg_to_i64(args[i], native_arg_type_id(f, i))
-
-  var result_i64: int64
-  case args.len
-  of 0:
-    result_i64 = cast[NativeFn0](f.native_entry)(addr ctx)
-  of 1:
-    result_i64 = cast[NativeFn1](f.native_entry)(addr ctx, marshaled_args[0])
-  of 2:
-    result_i64 = cast[NativeFn2](f.native_entry)(addr ctx, marshaled_args[0], marshaled_args[1])
-  of 3:
-    result_i64 = cast[NativeFn3](f.native_entry)(addr ctx, marshaled_args[0], marshaled_args[1], marshaled_args[2])
-  of 4:
-    result_i64 = cast[NativeFn4](f.native_entry)(
-      addr ctx, marshaled_args[0], marshaled_args[1], marshaled_args[2], marshaled_args[3]
-    )
-  of 5:
-    result_i64 = cast[NativeFn5](f.native_entry)(
-      addr ctx, marshaled_args[0], marshaled_args[1], marshaled_args[2], marshaled_args[3], marshaled_args[4]
-    )
-  of 6:
-    result_i64 = cast[NativeFn6](f.native_entry)(
-      addr ctx, marshaled_args[0], marshaled_args[1], marshaled_args[2], marshaled_args[3], marshaled_args[4], marshaled_args[5]
-    )
-  of 7:
-    result_i64 = cast[NativeFn7](f.native_entry)(
-      addr ctx, marshaled_args[0], marshaled_args[1], marshaled_args[2], marshaled_args[3],
-      marshaled_args[4], marshaled_args[5], marshaled_args[6]
-    )
-  else:
-    return false
-  # Unbox result: if return type is float, bitcast int64 back to float64
+proc unbox_native_result(f: Function, result_i64: int64, out_value: var Value) {.inline.} =
   if f.native_return_float:
     out_value = cast[float64](result_i64).to_value()
   elif f.native_return_value:
@@ -162,4 +126,64 @@ proc try_native_call(self: ptr VirtualMachine, f: Function, args: seq[Value], ou
     out_value = cast[Value](STRING_TAG or payload)
   else:
     out_value = result_i64.to_value()
+
+proc try_native_call0(self: ptr VirtualMachine, f: Function, out_value: var Value): bool =
+  if self.effective_native_tier() == NctNever:
+    return false
+  if not native_call_supported0(self, f):
+    return false
+  var ctx: NativeContext
+  if not self.prepare_native_ctx(f, ctx):
+    return false
+  let result_i64 = cast[NativeFn0](f.native_entry)(addr ctx)
+  unbox_native_result(f, result_i64, out_value)
+  true
+
+proc try_native_call1(self: ptr VirtualMachine, f: Function, arg: Value, out_value: var Value): bool =
+  if self.effective_native_tier() == NctNever:
+    return false
+  if not native_call_supported1(self, f, arg):
+    return false
+  var ctx: NativeContext
+  if not self.prepare_native_ctx(f, ctx):
+    return false
+  let a0 = arg_to_i64(arg, native_arg_type_id(f, 0))
+  let result_i64 = cast[NativeFn1](f.native_entry)(addr ctx, a0)
+  unbox_native_result(f, result_i64, out_value)
+  true
+
+proc try_native_call(self: ptr VirtualMachine, f: Function, args: seq[Value], out_value: var Value): bool =
+  if self.effective_native_tier() == NctNever:
+    return false
+  if not native_call_supported(self, f, args):
+    return false
+  var ctx: NativeContext
+  if not self.prepare_native_ctx(f, ctx):
+    return false
+
+  var m: array[8, int64]  # Stack-allocated marshal buffer (max 7 args + headroom)
+  for i in 0..<args.len:
+    m[i] = arg_to_i64(args[i], native_arg_type_id(f, i))
+
+  var result_i64: int64
+  case args.len
+  of 0:
+    result_i64 = cast[NativeFn0](f.native_entry)(addr ctx)
+  of 1:
+    result_i64 = cast[NativeFn1](f.native_entry)(addr ctx, m[0])
+  of 2:
+    result_i64 = cast[NativeFn2](f.native_entry)(addr ctx, m[0], m[1])
+  of 3:
+    result_i64 = cast[NativeFn3](f.native_entry)(addr ctx, m[0], m[1], m[2])
+  of 4:
+    result_i64 = cast[NativeFn4](f.native_entry)(addr ctx, m[0], m[1], m[2], m[3])
+  of 5:
+    result_i64 = cast[NativeFn5](f.native_entry)(addr ctx, m[0], m[1], m[2], m[3], m[4])
+  of 6:
+    result_i64 = cast[NativeFn6](f.native_entry)(addr ctx, m[0], m[1], m[2], m[3], m[4], m[5])
+  of 7:
+    result_i64 = cast[NativeFn7](f.native_entry)(addr ctx, m[0], m[1], m[2], m[3], m[4], m[5], m[6])
+  else:
+    return false
+  unbox_native_result(f, result_i64, out_value)
   true


### PR DESCRIPTION
## Summary
Implements a read cache for caller-saved registers (X9-X15) in the ARM64 code generator to reduce redundant stack loads during HIR-to-native compilation. This optimization improves performance by keeping frequently-accessed HIR register values in physical registers across multiple operations.

## Key Changes

### ARM64 Code Generator (`src/gene/native/arm64_codegen.nim`)
- **Added read cache infrastructure**: 
  - New `readCache` field in `CodegenContext` to track which HIR registers are cached in X9-X15
  - `cachedLoad()` and `cachedStore()` procedures that check the cache before loading/storing from stack
  - Cache management: `cacheFind()`, `cacheAllocSlot()`, `invalidateCache()`, `cacheInvalidateReg()`
  - Simple round-robin eviction policy when cache is full

- **Updated all integer operations** to use `cachedLoad()`/`cachedStore()` instead of direct `loadReg()`/`storeReg()`:
  - Arithmetic: `genAddI64`, `genSubI64`, `genMulI64`, `genDivI64`, `genModI64`, `genNegI64`
  - Comparisons: `genLeI64`, `genLtI64`, `genGeI64`, `genGtI64`, `genEqI64`, `genNeI64`
  - Float comparisons: `genLeF64`, `genLtF64`, `genGeF64`, `genGtF64`, `genEqF64`, `genNeF64`
  - String operations: `genBoxString`, `genUnboxString`
  - Call sites: `genCall`, `genCallVM`, `genBr`

- **Cache invalidation at control flow boundaries**:
  - `genBr()`, `genJump()`: invalidate cache before branches
  - `genBlock()`: invalidate at block entry (predecessors may differ)
  - `genModF64()`, `genCallVM()`: invalidate after function calls that clobber caller-saved registers

- **Float operations**: Added `cacheInvalidateReg()` calls after FP operations that write to stack, since FP registers don't use the cache

### Native Call Optimization (`src/gene/vm/native.nim`)
- **Extracted common preamble**: New `prepare_native_ctx()` procedure consolidates native context setup
- **Fast paths for 0 and 1 argument calls**: 
  - `try_native_call0()` and `try_native_call1()` avoid seq allocation overhead
  - Specialized type checking via `native_args_supported0()` and `native_args_supported1()`
- **Unified result unboxing**: New `unbox_native_result()` procedure eliminates code duplication
- **Stack-allocated marshal buffer**: Changed from dynamic `seq` to fixed 8-element array for argument marshaling

### Helper Functions (`src/gene/vm/core_helpers.nim`)
- Added `native_args_supported0()`, `native_args_supported1()`, `native_call_supported0()`, `native_call_supported1()` for fast-path validation

### Benchmark (`benchmarks/computation/fibonacci_compare.nim`)
- New benchmark comparing VM interpreter vs native compilation performance on recursive Fibonacci

## Implementation Details
- Cache uses 7 caller-saved registers (X9-X15) with -1 sentinel for empty slots
- Write-through cache: stores always update both stack and cache
- No dirty tracking needed since all writes go to stack immediately
- Cache invalidation is conservative: clears entire cache at control flow boundaries to handle multiple predecessors safely

https://claude.ai/code/session_01RTdxMBTsizdm7aWyyA5CaW